### PR TITLE
ci: 在检查脚本失败时导出组件错误日志

### DIFF
--- a/.github/workflows/pr-e2e-7niu-release-1.15.yaml
+++ b/.github/workflows/pr-e2e-7niu-release-1.15.yaml
@@ -246,6 +246,9 @@ jobs:
         run: make "$SUITE_TARGET"
 
       - name: Check kube ovn pod restarts
+        if: always()
+        env:
+          EXPORT_COMPONENT_ERROR_LOGS: ${{ failure() }}
         run: make check-kube-ovn-pod-restarts
 
   master-ha-e2e:
@@ -338,6 +341,9 @@ jobs:
         run: make kube-ovn-ha-e2e
 
       - name: Check kube ovn pod restarts
+        if: always()
+        env:
+          EXPORT_COMPONENT_ERROR_LOGS: ${{ failure() }}
         run: make check-kube-ovn-pod-restarts
 
   master-multus-e2e:
@@ -434,6 +440,9 @@ jobs:
         run: make kube-ovn-multus-conformance-e2e
 
       - name: Check kube ovn pod restarts
+        if: always()
+        env:
+          EXPORT_COMPONENT_ERROR_LOGS: ${{ failure() }}
         run: make check-kube-ovn-pod-restarts
 
   master-iptables-vpc-nat-gw-e2e:
@@ -535,4 +544,7 @@ jobs:
         run: make iptables-vpc-nat-gw-conformance-e2e
 
       - name: Check kube ovn pod restarts
+        if: always()
+        env:
+          EXPORT_COMPONENT_ERROR_LOGS: ${{ failure() }}
         run: make check-kube-ovn-pod-restarts

--- a/.github/workflows/pr-e2e-7niu-release-1.15.yaml
+++ b/.github/workflows/pr-e2e-7niu-release-1.15.yaml
@@ -237,6 +237,7 @@ jobs:
         run: make kind-install-overlay-ipv4
 
       - name: Run master e2e
+        id: e2e
         working-directory: test/e2e/source
         env:
           E2E_BRANCH: ${{ env.TARGET_BRANCH }}
@@ -248,7 +249,7 @@ jobs:
       - name: Check kube ovn pod restarts
         if: always()
         env:
-          EXPORT_COMPONENT_ERROR_LOGS: ${{ failure() }}
+          EXPORT_COMPONENT_ERROR_LOGS: ${{ steps.e2e.conclusion == 'failure' }}
         run: make check-kube-ovn-pod-restarts
 
   master-ha-e2e:
@@ -333,6 +334,7 @@ jobs:
         run: make kind-install-ipv4
 
       - name: Run master e2e
+        id: e2e
         working-directory: test/e2e/source
         env:
           E2E_BRANCH: ${{ env.TARGET_BRANCH }}
@@ -343,7 +345,7 @@ jobs:
       - name: Check kube ovn pod restarts
         if: always()
         env:
-          EXPORT_COMPONENT_ERROR_LOGS: ${{ failure() }}
+          EXPORT_COMPONENT_ERROR_LOGS: ${{ steps.e2e.conclusion == 'failure' }}
         run: make check-kube-ovn-pod-restarts
 
   master-multus-e2e:
@@ -432,6 +434,7 @@ jobs:
         run: make kind-install-multus
 
       - name: Run master e2e
+        id: e2e
         working-directory: test/e2e/source
         env:
           E2E_BRANCH: ${{ env.TARGET_BRANCH }}
@@ -442,7 +445,7 @@ jobs:
       - name: Check kube ovn pod restarts
         if: always()
         env:
-          EXPORT_COMPONENT_ERROR_LOGS: ${{ failure() }}
+          EXPORT_COMPONENT_ERROR_LOGS: ${{ steps.e2e.conclusion == 'failure' }}
         run: make check-kube-ovn-pod-restarts
 
   master-iptables-vpc-nat-gw-e2e:
@@ -536,6 +539,7 @@ jobs:
         run: make kind-install-vpc-nat-gw
 
       - name: Run master e2e
+        id: e2e
         working-directory: test/e2e/source
         env:
           E2E_BRANCH: ${{ env.TARGET_BRANCH }}
@@ -546,5 +550,5 @@ jobs:
       - name: Check kube ovn pod restarts
         if: always()
         env:
-          EXPORT_COMPONENT_ERROR_LOGS: ${{ failure() }}
+          EXPORT_COMPONENT_ERROR_LOGS: ${{ steps.e2e.conclusion == 'failure' }}
         run: make check-kube-ovn-pod-restarts

--- a/hack/ci-check-crash.sh
+++ b/hack/ci-check-crash.sh
@@ -54,9 +54,9 @@ function export_error_logs() {
   for component in "${components[@]}"; do
     echo "--- Error logs for $component ---"
     # Fallback to kubectl logs filtering by error, ko log might output to files
-    kubectl logs -n "$namespace" -l app="$component" --tail=2000 | grep -v -i info || echo "Warning: failed to get logs for $component"
+    kubectl logs -n "$namespace" -l app="$component" --tail=2000 | grep -i "error\|fatal\|panic\|warn" || echo "Warning: failed to get logs for $component"
     echo "--- Previous error logs for $component (if any) ---"
-    kubectl logs -n "$namespace" -l app="$component" -p --tail=2000 | grep -v -i info || true
+    kubectl logs -n "$namespace" -l app="$component" -p --tail=2000 | grep -i "error\|fatal\|panic\|warn" || echo "Warning: failed to get previous logs for $component (may not exist)"
     echo "-----------------------------------"
   done
 }

--- a/hack/ci-check-crash.sh
+++ b/hack/ci-check-crash.sh
@@ -52,11 +52,20 @@ function export_error_logs() {
   local components=("kube-ovn-controller" "kube-ovn-cni" "kube-ovn-pinger")
   echo ">>> Fetching logs for ${components[*]}..."
   for component in "${components[@]}"; do
+    local currentLogs=""
+    local previousLogs=""
     echo "--- Error logs for $component ---"
-    # Fallback to kubectl logs filtering by error, ko log might output to files
-    kubectl logs -n "$namespace" -l app="$component" --tail=2000 | grep -i "error\|fatal\|panic\|warn" || echo "Warning: failed to get logs for $component"
+    if currentLogs=$(kubectl logs -n "$namespace" -l app="$component" --tail=2000); then
+      echo "$currentLogs" | grep -i "error\|fatal\|panic\|warn" || true
+    else
+      echo "Warning: failed to get logs for $component"
+    fi
     echo "--- Previous error logs for $component (if any) ---"
-    kubectl logs -n "$namespace" -l app="$component" -p --tail=2000 | grep -i "error\|fatal\|panic\|warn" || echo "Warning: failed to get previous logs for $component (may not exist)"
+    if previousLogs=$(kubectl logs -n "$namespace" -l app="$component" -p --tail=2000); then
+      echo "$previousLogs" | grep -i "error\|fatal\|panic\|warn" || true
+    else
+      echo "Warning: failed to get previous logs for $component (may not exist)"
+    fi
     echo "-----------------------------------"
   done
 }

--- a/hack/ci-check-crash.sh
+++ b/hack/ci-check-crash.sh
@@ -48,4 +48,20 @@ for pod in `kubectl get pod -n $namespace -l component=network -o name`; do
   done
 done
 
+function export_error_logs() {
+  local namespace="kube-system"
+  local components=("kube-ovn-controller" "kube-ovn-cni" "kube-ovn-pinger")
+  echo ">>> Fetching error logs for ${components[*]} using kubectl-ko..."
+  for component in "${components[@]}"; do
+    echo "--- Error logs for $component ---"
+    # Fallback to kubectl logs filtering by error, ko log might output to files
+    kubectl logs -n "$namespace" -l app="$component" --tail=-1 | grep -v -i info || true
+    echo "-----------------------------------"
+  done
+}
+
+if [ $exit_code -ne 0 ]; then
+  export_error_logs
+fi
+
 exit $exit_code

--- a/hack/ci-check-crash.sh
+++ b/hack/ci-check-crash.sh
@@ -61,7 +61,7 @@ function export_error_logs() {
   done
 }
 
-if [ $exit_code -ne 0 ]; then
+if [ "${EXPORT_COMPONENT_ERROR_LOGS:-false}" = "true" ] || [ $exit_code -ne 0 ]; then
   export_error_logs
 fi
 

--- a/hack/ci-check-crash.sh
+++ b/hack/ci-check-crash.sh
@@ -49,13 +49,14 @@ for pod in `kubectl get pod -n $namespace -l component=network -o name`; do
 done
 
 function export_error_logs() {
-  local namespace="kube-system"
   local components=("kube-ovn-controller" "kube-ovn-cni" "kube-ovn-pinger")
-  echo ">>> Fetching error logs for ${components[*]} using kubectl-ko..."
+  echo ">>> Fetching logs for ${components[*]}..."
   for component in "${components[@]}"; do
     echo "--- Error logs for $component ---"
     # Fallback to kubectl logs filtering by error, ko log might output to files
-    kubectl logs -n "$namespace" -l app="$component" --tail=-1 | grep -v -i info || true
+    kubectl logs -n "$namespace" -l app="$component" --tail=2000 | grep -v -i info || echo "Warning: failed to get logs for $component"
+    echo "--- Previous error logs for $component (if any) ---"
+    kubectl logs -n "$namespace" -l app="$component" -p --tail=2000 | grep -v -i info || true
     echo "-----------------------------------"
   done
 }


### PR DESCRIPTION
在 CI 检查脚本中增加错误日志导出函数。当脚本因检测到崩溃而退出时，自动获取并输出 kube-ovn-controller、kube-ovn-cni 和 kube-ovn-pinger 组件的错误日志，以便于快速定位问题。

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
