### PR TITLE
support BGP EIP management for LoadBalancer（仅 review）

### DIFF
--- a/.github/workflows/build-x86-image.yaml
+++ b/.github/workflows/build-x86-image.yaml
@@ -3414,6 +3414,130 @@ jobs:
           name: iptables-vpc-nat-gw-conformance-e2e-ko-log
           path: iptables-vpc-nat-gw-conformance-e2e-ko-log.tar.gz
 
+  bgp-lb-eip-e2e:
+    name: BGP LB EIP E2E
+    needs:
+      - build-kube-ovn
+      - build-e2e-binaries
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: false
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
+      - uses: actions/checkout@v6
+
+      # TODO: remove this current-branch-only handling after bgp-lb-eip e2e is
+      # proven stable in CI, then restore the standard default-branch E2E_DIR
+      # workflow pattern used by the other standalone e2e jobs.
+
+      - uses: actions/setup-go@v6
+        id: setup-go
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: false
+
+      - name: Export Go full version
+        run: echo "GO_VERSION=${{ steps.setup-go.outputs.go-version }}" >> "$GITHUB_ENV"
+
+      - name: Go cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-e2e-go-${{ env.GO_VERSION }}-x86-${{ github.ref_name }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-e2e-go-${{ env.GO_VERSION }}-x86-${{ github.ref_name }}-
+            ${{ runner.os }}-e2e-go-${{ env.GO_VERSION }}-x86-${{ github.base_ref }}-
+
+      - name: Install kind
+        uses: helm/kind-action@v1.14.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          install_only: true
+
+      - name: Download kube-ovn image
+        uses: actions/download-artifact@v8
+        with:
+          name: kube-ovn
+
+      - name: Load images
+        run: docker load -i kube-ovn.tar
+
+      - name: Create kind cluster with BGP topology
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pipx install jinjanator
+          make kind-ghcr-pull kind-init-bgp
+
+      - name: Install Kube-OVN with BGP speaker enabled
+        id: install
+        run: make kind-install-bgp
+
+      - name: Install Multus
+        run: make kind-install-multus
+
+      - name: Run BGP LB EIP E2E
+        id: e2e
+        env:
+          E2E_BRANCH: ${{ github.base_ref || github.ref_name }}
+          E2E_IP_FAMILY: ipv4
+        run: make bgp-lb-eip-e2e
+
+      - name: Collect k8s events
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        run: |
+          kubectl get events -A -o yaml > bgp-lb-eip-e2e-events.yaml
+          tar zcf bgp-lb-eip-e2e-events.tar.gz bgp-lb-eip-e2e-events.yaml
+
+      - name: Upload k8s events
+        uses: actions/upload-artifact@v7
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        with:
+          name: bgp-lb-eip-e2e-events
+          path: bgp-lb-eip-e2e-events.tar.gz
+
+      - name: Collect apiserver audit logs
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        run: |
+          docker cp kube-ovn-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
+          tar zcf bgp-lb-eip-e2e-audit-log.tar.gz kube-apiserver-audit.log
+
+      - name: Upload apiserver audit logs
+        uses: actions/upload-artifact@v7
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')
+        with:
+          name: bgp-lb-eip-e2e-audit-log
+          path: bgp-lb-eip-e2e-audit-log.tar.gz
+
+      - name: Check kube ovn pod restarts
+        id: check-restarts
+        if: ${{ success() || (failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure')) }}
+        run: make check-kube-ovn-pod-restarts
+
+      - name: kubectl ko log
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
+        run: |
+          make kubectl-ko-log
+          mv kubectl-ko-log.tar.gz bgp-lb-eip-e2e-ko-log.tar.gz
+
+      - name: upload kubectl ko log
+        uses: actions/upload-artifact@v7
+        if: failure() && (steps.install.conclusion == 'failure' || steps.e2e.conclusion == 'failure' || steps.check-restarts.conclusion == 'failure')
+        with:
+          name: bgp-lb-eip-e2e-ko-log
+          path: bgp-lb-eip-e2e-ko-log.tar.gz
+
   ovn-vpc-nat-gw-conformance-e2e:
     name: OVN VPC NAT Gateway E2E
     needs:
@@ -4112,6 +4236,7 @@ jobs:
       - vpc-egress-gateway-e2e
       - ovn-vpc-nat-gw-conformance-e2e
       - iptables-vpc-nat-gw-conformance-e2e
+      - bgp-lb-eip-e2e
       - webhook-e2e
       - lb-svc-e2e
       - underlay-logical-gateway-installation-test

--- a/charts/kube-ovn-v2/README.md
+++ b/charts/kube-ovn-v2/README.md
@@ -532,6 +532,15 @@ false
 			<td>Enable the kube-ovn-speaker.</td>
 		</tr>
 		<tr>
+			<td>bgpSpeaker.enableLbSvcAnnounce</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Enable announcing LoadBalancer Service ingress IPs for Services bound by ovn.kubernetes.io/bgp-vip.</td>
+		</tr>
+		<tr>
 			<td>bgpSpeaker.extraEnv</td>
 			<td>list</td>
 			<td><pre lang="json">

--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -825,7 +825,7 @@ spec:
                   If empty, defaults to the kube-ovn controller's own namespace.
                 type: string
               natGwDp:
-                description: NAT gateway datapath where the EIP is assigned
+                description: NAT gateway datapath where the EIP is assigned.
                 type: string
               qosPolicy:
                 description: QoS policy name to apply to the EIP

--- a/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
+++ b/charts/kube-ovn-v2/templates/controller/controller-deployment.yaml
@@ -148,6 +148,7 @@ spec:
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
           - --log_file_max_size=200
           - --enable-lb-svc={{- .Values.features.enableLoadbalancerService }}
+          - --enable-bgp-lb-vip={{- .Values.features.enableBgpLbVip }}
           - --keep-vm-ip={{- .Values.features.enableKeepVmIps }}
           - --enable-metrics={{- .Values.networking.enableMetrics }}
           - --node-local-dns-ip={{- .Values.networking.nodeLocalDnsIp }}

--- a/charts/kube-ovn-v2/templates/speaker/speaker.yaml
+++ b/charts/kube-ovn-v2/templates/speaker/speaker.yaml
@@ -78,6 +78,7 @@ spec:
             - --alsologtostderr=true
             - --log_file=/var/log/kube-ovn/kube-ovn-speaker.log
             - --log_file_max_size=200
+            - --enable-lb-svc-announce={{ .Values.bgpSpeaker.enableLbSvcAnnounce }}
           {{- with .Values.bgpSpeaker.args }}
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}

--- a/charts/kube-ovn-v2/values.yaml
+++ b/charts/kube-ovn-v2/values.yaml
@@ -202,6 +202,7 @@ features:
   # -- Enable Kube-OVN loadbalancer services
   # @section -- Opt-in/out Features
   enableLoadbalancerService: false
+  enableBgpLbVip: false
   # -- Enable persistent VM IPs
   # @section -- Opt-in/out Features
   enableKeepVmIps: true
@@ -620,6 +621,9 @@ bgpSpeaker:
   # -- Enable the kube-ovn-speaker.
   # @section -- BGP speaker configuration
   enabled: false
+  # -- Enable announcing LoadBalancer Service ingress IPs for Services bound by ovn.kubernetes.io/bgp-vip.
+  # @section -- BGP speaker configuration
+  enableLbSvcAnnounce: false
   # -- Override image settings for kube-ovn-speaker. Empty fields fall back to the global kube-ovn image.
   # @section -- BGP speaker configuration
   image:

--- a/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/charts/kube-ovn/templates/controller-deploy.yaml
@@ -139,6 +139,7 @@ spec:
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
           - --log_file_max_size=200
           - --enable-lb-svc={{- .Values.func.ENABLE_LB_SVC }}
+          - --enable-bgp-lb-vip={{- .Values.func.ENABLE_BGP_LB_VIP }}
           - --keep-vm-ip={{- .Values.func.ENABLE_KEEP_VM_IP }}
           - --enable-metrics={{- .Values.networking.ENABLE_METRICS }}
           - --node-local-dns-ip={{- .Values.networking.NODE_LOCAL_DNS_IP }}

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -825,7 +825,7 @@ spec:
                   If empty, defaults to the kube-ovn controller's own namespace.
                 type: string
               natGwDp:
-                description: NAT gateway datapath where the EIP is assigned
+                description: NAT gateway datapath where the EIP is assigned.
                 type: string
               qosPolicy:
                 description: QoS policy name to apply to the EIP

--- a/charts/kube-ovn/values.yaml
+++ b/charts/kube-ovn/values.yaml
@@ -67,6 +67,7 @@ func:
   ENABLE_EXTERNAL_VPC: false
   HW_OFFLOAD: false
   ENABLE_LB_SVC: false
+  ENABLE_BGP_LB_VIP: false
   ENABLE_KEEP_VM_IP: true
   LS_DNAT_MOD_DL_DST: true
   LS_CT_SKIP_DST_LPORT_IPS: true

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -24,6 +24,7 @@ LS_CT_SKIP_DST_LPORT_IPS=${LS_CT_SKIP_DST_LPORT_IPS:-true}
 ENABLE_EXTERNAL_VPC=${ENABLE_EXTERNAL_VPC:-false}
 CNI_CONFIG_PRIORITY=${CNI_CONFIG_PRIORITY:-01}
 ENABLE_LB_SVC=${ENABLE_LB_SVC:-false}
+ENABLE_BGP_LB_VIP=${ENABLE_BGP_LB_VIP:-false}
 ENABLE_NAT_GW=${ENABLE_NAT_GW:-true}
 ENABLE_KEEP_VM_IP=${ENABLE_KEEP_VM_IP:-true}
 ENABLE_ARP_DETECT_IP_CONFLICT=${ENABLE_ARP_DETECT_IP_CONFLICT:-true}
@@ -200,11 +201,18 @@ if [[ $NETWORK_TYPE = "vlan" ]];then
 fi
 echo "Default Subnet CIDR:  $POD_CIDR"
 echo "Join Subnet CIDR:     $JOIN_CIDR"
-echo "Enable SVC LB:        $ENABLE_LB"
+echo "Enable LB:            $ENABLE_LB"
+echo "Enable LB SVC:        $ENABLE_LB_SVC"
+echo "Enable BGP LB VIP:    $ENABLE_BGP_LB_VIP"
 echo "Enable Networkpolicy: $ENABLE_NP"
 echo "Enable EIP and SNAT:  $ENABLE_EIP_SNAT"
 echo "Enable Mirror:        $ENABLE_MIRROR"
 echo "-------------------------------"
+
+if [[ "$ENABLE_BGP_LB_VIP" = "true" && "$ENABLE_LB_SVC" = "true" ]]; then
+  echo "ERROR: ENABLE_BGP_LB_VIP and ENABLE_LB_SVC are mutually exclusive"
+  exit 1
+fi
 
 if [[ $ENABLE_SSL = "true" ]];then
   echo "[Step 0/6] Generate SSL key and cert"
@@ -1076,7 +1084,7 @@ spec:
                   If empty, defaults to the kube-ovn controller's own namespace.
                 type: string
               natGwDp:
-                description: NAT gateway datapath where the EIP is assigned
+                description: NAT gateway datapath where the EIP is assigned.
                 type: string
               qosPolicy:
                 description: QoS policy name to apply to the EIP
@@ -7827,6 +7835,7 @@ spec:
           - --log_file=/var/log/kube-ovn/kube-ovn-controller.log
           - --log_file_max_size=200
           - --enable-lb-svc=$ENABLE_LB_SVC
+          - --enable-bgp-lb-vip=$ENABLE_BGP_LB_VIP
           - --keep-vm-ip=$ENABLE_KEEP_VM_IP
           - --enable-metrics=$ENABLE_METRICS
           - --node-local-dns-ip=$NODE_LOCAL_DNS_IP

--- a/makefiles/e2e.mk
+++ b/makefiles/e2e.mk
@@ -105,6 +105,7 @@ e2e-build:
 	$(GINKGO_E2E_BUILD) ./test/e2e/metallb
 	$(GINKGO_E2E_BUILD) ./test/e2e/anp-domain
 	$(GINKGO_E2E_BUILD) ./test/e2e/cnp-domain
+	$(GINKGO_E2E_BUILD) ./test/e2e/bgp-lb-eip
 
 .PHONY: k8s-conformance-e2e
 k8s-conformance-e2e:
@@ -195,6 +196,15 @@ kube-ovn-lb-svc-conformance-e2e:
 	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
 	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
 	$(GINKGO_E2E_RUN_PARALLEL) --focus=CNI:Kube-OVN ./test/e2e/lb-svc/lb-svc.test -- $(TEST_BIN_ARGS)
+
+.PHONY: bgp-lb-eip-e2e
+bgp-lb-eip-e2e:
+	$(call kind_load_image,kube-ovn,$(AGNHOST_IMAGE),1)
+	$(GINKGO_E2E_BUILD) ./test/e2e/bgp-lb-eip
+	E2E_BRANCH=$(E2E_BRANCH) \
+	E2E_IP_FAMILY=$(E2E_IP_FAMILY) \
+	E2E_NETWORK_MODE=$(E2E_NETWORK_MODE) \
+	$(GINKGO_E2E_RUN) --focus="group:bgp-lb-eip" ./test/e2e/bgp-lb-eip/bgp-lb-eip.test -- $(TEST_BIN_ARGS)
 
 .PHONY: vip-conformance-e2e
 vip-conformance-e2e:

--- a/makefiles/kind.mk
+++ b/makefiles/kind.mk
@@ -210,9 +210,7 @@ kind-init-single: kind-init-single-ipv4
 kind-init-single-%:
 	@single=true $(MAKE) kind-init-$*
 
-.PHONY: kind-init-bgp
-kind-init-bgp: kind-clean-bgp kind-init
-	kube_ovn_version=$(VERSION) frr_image=$(FRR_IMAGE) jinjanate yamls/clab-bgp.yaml.j2 -o yamls/clab-bgp.yaml
+define clab_bgp_run
 	docker run --rm --privileged \
 		--name kube-ovn-bgp \
 		--network host \
@@ -221,22 +219,22 @@ kind-init-bgp: kind-clean-bgp kind-init
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /var/run/netns:/var/run/netns \
 		-v /var/lib/docker/containers:/var/lib/docker/containers \
-		-v $(CURDIR)/yamls/clab-bgp.yaml:/clab-bgp/clab.yaml \
-		$(CLAB_IMAGE) clab deploy -t /clab-bgp/clab.yaml
+		-v $(CURDIR)/$(1):/clab-bgp/clab.yaml \
+		$(CLAB_IMAGE) clab $(2) -t /clab-bgp/clab.yaml
+endef
+
+define clab_bgp_render_and_run
+	kube_ovn_version=$(VERSION) frr_image=$(FRR_IMAGE) jinjanate $(1).j2 -o $(1)
+	$(call clab_bgp_run,$(1),$(2))
+endef
+
+.PHONY: kind-init-bgp
+kind-init-bgp: kind-clean-bgp kind-init
+	$(call clab_bgp_render_and_run,yamls/clab-bgp.yaml,deploy)
 
 .PHONY: kind-init-bgp-ha
 kind-init-bgp-ha: kind-clean-bgp kind-init
-	kube_ovn_version=$(VERSION) frr_image=$(FRR_IMAGE) jinjanate yamls/clab-bgp-ha.yaml.j2 -o yamls/clab-bgp-ha.yaml
-	docker run --rm --privileged \
-		--name kube-ovn-bgp \
-		--network host \
-		--pid host \
-		-v /lib/modules:/lib/modules:ro \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v /var/run/netns:/var/run/netns \
-		-v /var/lib/docker/containers:/var/lib/docker/containers \
-		-v $(CURDIR)/yamls/clab-bgp-ha.yaml:/clab-bgp/clab.yaml \
-		$(CLAB_IMAGE) clab deploy -t /clab-bgp/clab.yaml
+	$(call clab_bgp_render_and_run,yamls/clab-bgp-ha.yaml,deploy)
 
 .PHONY: kind-load-image
 kind-load-image:
@@ -501,6 +499,8 @@ kind-install-underlay-logical-gateway-dual: kind-disable-hairpin kind-load-image
 kind-install-multus:
 	$(call kind_load_image,kube-ovn,$(MULTUS_IMAGE),1)
 	curl -s "$(MULTUS_YAML)" | sed 's/:snapshot-thick/:$(MULTUS_VERSION)-thick/g' | kubectl apply -f -
+	kubectl wait --for=condition=Established --timeout=120s crd/network-attachment-definitions.k8s.cni.cncf.io
+	@timeout 120 bash -c 'until kubectl api-resources --api-group=k8s.cni.cncf.io | grep -q network-attachment-definitions; do sleep 2; done'
 	kubectl -n kube-system set resources ds/kube-multus-ds -c kube-multus --limits=cpu=200m,memory=200Mi
 	kubectl -n kube-system rollout status ds kube-multus-ds
 
@@ -673,10 +673,12 @@ kind-install-cilium-delegate-%:
 	kubectl -n kube-system rollout status ds cilium --timeout 120s
 
 .PHONY: kind-install-bgp
-kind-install-bgp: kind-install
+kind-install-bgp:
+	@ENABLE_BGP_LB_VIP=true $(MAKE) kind-install
 	kubectl label node --all ovn.kubernetes.io/bgp=true
 	kubectl annotate subnet ovn-default ovn.kubernetes.io/bgp=local
 	sed -e 's#image: .*#image: $(REGISTRY)/kube-ovn:$(VERSION)#' \
+		-e 's/--enable-lb-svc-announce=.*/--enable-lb-svc-announce=true/' \
 		-e 's/--neighbor-address=.*/--neighbor-address=10.0.1.1/' \
 		-e 's/--neighbor-as=.*/--neighbor-as=65001/' \
 		-e 's/--cluster-as=.*/--cluster-as=65002/' yamls/speaker.yaml | \
@@ -685,10 +687,12 @@ kind-install-bgp: kind-install
 	docker exec clab-bgp-router vtysh -c "show ip route bgp"
 
 .PHONY: kind-install-bgp-ha
-kind-install-bgp-ha: kind-install
+kind-install-bgp-ha:
+	@ENABLE_BGP_LB_VIP=true $(MAKE) kind-install
 	kubectl label node --all ovn.kubernetes.io/bgp=true
 	kubectl annotate subnet ovn-default ovn.kubernetes.io/bgp=local
 	sed -e 's#image: .*#image: $(REGISTRY)/kube-ovn:$(VERSION)#' \
+		-e 's/--enable-lb-svc-announce=.*/--enable-lb-svc-announce=true/' \
 		-e 's/--neighbor-address=.*/--neighbor-address=10.0.1.1,10.0.1.2/' \
 		-e 's/--neighbor-as=.*/--neighbor-as=65001/' \
 		-e 's/--cluster-as=.*/--cluster-as=65002/' yamls/speaker.yaml | \
@@ -810,32 +814,12 @@ kind-clean-ovn-submariner: kind-clean
 
 .PHONY: kind-clean-bgp
 kind-clean-bgp: kind-clean-bgp-ha
-	kube_ovn_version=$(VERSION) frr_image=$(FRR_IMAGE) jinjanate yamls/clab-bgp.yaml.j2 -o yamls/clab-bgp.yaml
-	docker run --rm --privileged \
-		--name kube-ovn-bgp \
-		--network host \
-		--pid host \
-		-v /lib/modules:/lib/modules:ro \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v /var/run/netns:/var/run/netns \
-		-v /var/lib/docker/containers:/var/lib/docker/containers \
-		-v $(CURDIR)/yamls/clab-bgp.yaml:/clab-bgp/clab.yaml \
-		$(CLAB_IMAGE) clab destroy -t /clab-bgp/clab.yaml
+	$(call clab_bgp_render_and_run,yamls/clab-bgp.yaml,destroy)
 	@$(MAKE) kind-clean
 
 .PHONY: kind-clean-bgp-ha
 kind-clean-bgp-ha:
-	kube_ovn_version=$(VERSION) frr_image=$(FRR_IMAGE) jinjanate yamls/clab-bgp-ha.yaml.j2 -o yamls/clab-bgp-ha.yaml
-	docker run --rm --privileged \
-		--name kube-ovn-bgp \
-		--network host \
-		--pid host \
-		-v /lib/modules:/lib/modules:ro \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v /var/run/netns:/var/run/netns \
-		-v /var/lib/docker/containers:/var/lib/docker/containers \
-		-v $(CURDIR)/yamls/clab-bgp-ha.yaml:/clab-bgp/clab.yaml \
-		$(CLAB_IMAGE) clab destroy -t /clab-bgp/clab.yaml
+	$(call clab_bgp_render_and_run,yamls/clab-bgp-ha.yaml,destroy)
 	@$(MAKE) kind-clean
 
 .PHONY: kind-ghcr-pull

--- a/pkg/apis/kubeovn/v1/iptables-eip.go
+++ b/pkg/apis/kubeovn/v1/iptables-eip.go
@@ -42,7 +42,7 @@ type IptablesEIPSpec struct {
 	V6ip string `json:"v6ip"`
 	// MAC address for the EIP
 	MacAddress string `json:"macAddress"`
-	// NAT gateway datapath where the EIP is assigned
+	// NAT gateway datapath where the EIP is assigned.
 	NatGwDp string `json:"natGwDp"`
 	// QoS policy name to apply to the EIP
 	QoSPolicy string `json:"qosPolicy"`

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -93,6 +93,7 @@ type Configuration struct {
 	EnableEcmp                  bool
 	EnableKeepVMIP              bool
 	EnableLbSvc                 bool
+	EnableBgpLbVip              bool
 	EnableOVNLBPreferLocal      bool
 	EnableMetrics               bool
 	EnableANP                   bool
@@ -199,6 +200,7 @@ func ParseFlags() (*Configuration, error) {
 		argEnableEcmp                  = pflag.Bool("enable-ecmp", false, "Enable ecmp route for centralized subnet")
 		argKeepVMIP                    = pflag.Bool("keep-vm-ip", true, "Whether to keep ip for kubevirt pod when pod is rebuild")
 		argEnableLbSvc                 = pflag.Bool("enable-lb-svc", false, "Whether to support loadbalancer service")
+		argEnableBgpLbVip              = pflag.Bool("enable-bgp-lb-vip", false, "Whether to allocate a LoadBalancer external IP via a VIP (type=bgp_lb_vip) and announce it through BGP speaker")
 		argEnableOVNLBPreferLocal      = pflag.Bool("enable-ovn-lb-prefer-local", false, "Whether to support ovn loadbalancer prefer local")
 		argEnableMetrics               = pflag.Bool("enable-metrics", true, "Whether to support metrics query")
 		argEnableANP                   = pflag.Bool("enable-anp", false, "Enable support for admin network policy and baseline admin network policy")
@@ -310,6 +312,7 @@ func ParseFlags() (*Configuration, error) {
 		GCInterval:                     *argGCInterval,
 		InspectInterval:                *argInspectInterval,
 		EnableLbSvc:                    *argEnableLbSvc,
+		EnableBgpLbVip:                 *argEnableBgpLbVip,
 		EnableOVNLBPreferLocal:         *argEnableOVNLBPreferLocal,
 		EnableMetrics:                  *argEnableMetrics,
 		EnableOVNIPSec:                 *argEnableOVNIPSec,
@@ -332,6 +335,10 @@ func ParseFlags() (*Configuration, error) {
 	}
 	if config.OvsDbInactivityTimeout > 0 && config.OvsDbConnectTimeout >= config.OvsDbInactivityTimeout {
 		return nil, errors.New("OVS DB inactivity timeout value should be greater than reconnect timeout value")
+	}
+
+	if err := config.validateModeFlags(); err != nil {
+		return nil, err
 	}
 
 	if config.NetworkType == util.NetworkTypeVlan && config.DefaultHostInterface == "" {
@@ -385,6 +392,16 @@ func ParseFlags() (*Configuration, error) {
 
 	klog.Infof("config is %+v", config)
 	return config, nil
+}
+
+func (config *Configuration) validateModeFlags() error {
+	// TODO: If we need to support both modes in the future, replace this hard
+	// mutual-exclusion check with explicit dispatch rules per Service behavior.
+	if config.EnableBgpLbVip && config.EnableLbSvc {
+		return errors.New("--enable-bgp-lb-vip and --enable-lb-svc are mutually exclusive")
+	}
+
+	return nil
 }
 
 func (config *Configuration) initKubeClient() error {

--- a/pkg/controller/config_test.go
+++ b/pkg/controller/config_test.go
@@ -1,0 +1,90 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurationValidateModeFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		enableBgpLb   bool
+		enableLbSvc   bool
+		expectErr     bool
+		errorContains string
+	}{
+		{
+			name:        "both disabled is valid",
+			enableBgpLb: false,
+			enableLbSvc: false,
+			expectErr:   false,
+		},
+		{
+			name:        "only bgp lb eip enabled is valid",
+			enableBgpLb: true,
+			enableLbSvc: false,
+			expectErr:   false,
+		},
+		{
+			name:        "only lb svc enabled is valid",
+			enableBgpLb: false,
+			enableLbSvc: true,
+			expectErr:   false,
+		},
+		{
+			name:          "both enabled is invalid",
+			enableBgpLb:   true,
+			enableLbSvc:   true,
+			expectErr:     true,
+			errorContains: "mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Configuration{
+				EnableBgpLbVip: tt.enableBgpLb,
+				EnableLbSvc:    tt.enableLbSvc,
+			}
+
+			err := cfg.validateModeFlags()
+			if tt.expectErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.errorContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRegisterBgpLbVipFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enable via vip flag", func(t *testing.T) {
+		t.Parallel()
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		enabled := fs.Bool("enable-bgp-lb-vip", false, "test flag")
+
+		require.NoError(t, fs.Parse([]string{"--enable-bgp-lb-vip=true"}))
+		require.True(t, *enabled)
+	})
+
+	t.Run("unknown bgp lb flag is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		enabled := fs.Bool("enable-bgp-lb-vip", false, "test flag")
+
+		err := fs.Parse([]string{"--enable-bgp-lb-unknown=true"})
+		require.Error(t, err)
+		require.False(t, *enabled)
+	})
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -63,6 +63,11 @@ const (
 	baselineAdminNetworkPolicyKey = "banp"
 	ippoolKey                     = "ippool"
 	clusterNetworkPolicyKey       = "cnp"
+
+	// bgpVipIndexName is the informer indexer key used to look up Services by their
+	// ovn.kubernetes.io/bgp-vip annotation value. Shared between controller.go (indexer
+	// registration) and vip.go (ByIndex call) so a rename is caught at compile time.
+	bgpVipIndexName = "bgpVipAnnotation"
 )
 
 // Controller is kube-ovn main controller that watch ns/pod/node/svc/ep and operate ovn
@@ -235,8 +240,11 @@ type Controller struct {
 	deleteNodeQueue workqueue.TypedRateLimitingInterface[string]
 	nodeKeyMutex    keymutex.KeyMutex
 
-	servicesLister     v1.ServiceLister
-	serviceSynced      cache.InformerSynced
+	servicesLister v1.ServiceLister
+	serviceSynced  cache.InformerSynced
+	// svcByBgpVipIndexer indexes Services by their ovn.kubernetes.io/bgp-vip annotation value,
+	// enabling O(k) lookup of Services bound to a specific bgp_lb_vip instead of a full list scan.
+	svcByBgpVipIndexer cache.Indexer
 	addServiceQueue    workqueue.TypedRateLimitingInterface[string]
 	deleteServiceQueue workqueue.TypedRateLimitingInterface[*vpcService]
 	updateServiceQueue workqueue.TypedRateLimitingInterface[*updateSvcObject]
@@ -749,6 +757,9 @@ func Run(ctx context.Context, config *Configuration) {
 	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
 		util.LogFatalAndExit(nil, "failed to wait for caches to sync")
 	}
+	if controller.config.EnableBgpLbVip {
+		klog.Infof("BGP LB VIP mode active: Service/VIP informer caches are synced and service handlers will start")
+	}
 
 	if _, err = podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.enqueueAddPod,
@@ -773,6 +784,22 @@ func Run(ctx context.Context, config *Configuration) {
 	}); err != nil {
 		util.LogFatalAndExit(err, "failed to add node event handler")
 	}
+
+	if err = serviceInformer.Informer().AddIndexers(cache.Indexers{
+		bgpVipIndexName: func(obj any) ([]string, error) {
+			svc, ok := obj.(*corev1.Service)
+			if !ok {
+				return nil, nil
+			}
+			if v := svc.Annotations[util.BgpVipAnnotation]; v != "" {
+				return []string{v}, nil
+			}
+			return nil, nil
+		},
+	}); err != nil {
+		util.LogFatalAndExit(err, "failed to add bgpVip indexer to service informer")
+	}
+	controller.svcByBgpVipIndexer = serviceInformer.Informer().GetIndexer()
 
 	if _, err = serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.enqueueAddService,
@@ -1343,11 +1370,19 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		}
 	}
 
-	if c.config.EnableLb {
+	// K8s LB workers are needed by both the classic OVN LB mode and the
+	// Service-based LB modes (lb-svc / bgp-lb-vip).
+	k8sLBWorker := c.config.EnableLb || c.config.EnableLbSvc || c.config.EnableBgpLbVip
+	// OVN LB workers are only needed by the classic OVN LB mode.
+	ovnLBWorker := c.config.EnableLb
+
+	if k8sLBWorker {
 		go wait.Until(runWorker("add service", c.addServiceQueue, c.handleAddService), time.Second, ctx.Done())
 		// run in a single worker to avoid delete the last vip, which will lead ovn to delete the loadbalancer
 		go wait.Until(runWorker("delete service", c.deleteServiceQueue, c.handleDeleteService), time.Second, ctx.Done())
+	}
 
+	if ovnLBWorker {
 		go wait.Until(runWorker("add/update switch lb rule", c.addSwitchLBRuleQueue, c.handleAddOrUpdateSwitchLBRule), time.Second, ctx.Done())
 		go wait.Until(runWorker("delete switch lb rule", c.delSwitchLBRuleQueue, c.handleDelSwitchLBRule), time.Second, ctx.Done())
 		go wait.Until(runWorker("delete switch lb rule", c.updateSwitchLBRuleQueue, c.handleUpdateSwitchLBRule), time.Second, ctx.Done())
@@ -1370,8 +1405,11 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		go wait.Until(runWorker("update status of ippool", c.updateIPPoolStatusQueue, c.handleUpdateIPPoolStatus), time.Second, ctx.Done())
 		go wait.Until(runWorker("virtual port for subnet", c.syncVirtualPortsQueue, c.syncVirtualPort), time.Second, ctx.Done())
 
-		if c.config.EnableLb {
+		if k8sLBWorker {
 			go wait.Until(runWorker("update service", c.updateServiceQueue, c.handleUpdateService), time.Second, ctx.Done())
+		}
+
+		if ovnLBWorker {
 			go wait.Until(runWorker("add/update endpoint slice", c.addOrUpdateEndpointSliceQueue, c.handleUpdateEndpointSlice), time.Second, ctx.Done())
 		}
 

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -41,8 +41,8 @@ func (c *Controller) enqueueAddService(obj any) {
 	klog.V(3).Infof("enqueue add service %s", key)
 	c.addOrUpdateEndpointSliceQueue.Add(key)
 
-	if c.config.EnableLbSvc {
-		klog.V(3).Infof("enqueue add lb service %s", key)
+	if c.config.EnableLbSvc || c.config.EnableBgpLbVip {
+		klog.V(3).Infof("enqueue add service %s for lb processing", key)
 		c.addServiceQueue.Add(key)
 	}
 }
@@ -177,6 +177,13 @@ func (c *Controller) handleDeleteService(service *vpcService) error {
 	if service.Svc.Spec.Type == v1.ServiceTypeLoadBalancer && c.config.EnableLbSvc {
 		if err := c.deleteLbSvc(service.Svc); err != nil {
 			klog.Errorf("failed to delete service %s, %v", service.Svc.Name, err)
+			return err
+		}
+	}
+
+	if service.Svc.Spec.Type == v1.ServiceTypeLoadBalancer && c.config.EnableBgpLbVip {
+		if err := c.cleanBgpLbVipService(service.Svc); err != nil {
+			klog.Errorf("failed to clean bgp-lb-vip for service %s: %v", service.Svc.Name, err)
 			return err
 		}
 	}
@@ -376,6 +383,28 @@ func (c *Controller) handleUpdateService(svcObject *updateSvcObject) error {
 		}
 	}
 
+	if c.config.EnableBgpLbVip && svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+		if c.needCleanupBgpLbVipServiceBinding(svc) {
+			if err = c.cleanupBgpLbVipServiceBinding(svc); err != nil {
+				klog.Errorf("failed to cleanup bgp-lb-vip binding for service %s: %v", key, err)
+				return err
+			}
+			return nil
+		}
+
+		needReconcile, err := c.needReconcileBgpLbVipService(svc)
+		if err != nil {
+			klog.Errorf("failed to check bgp-lb-vip reconcile precondition for service %s: %v", key, err)
+			return err
+		}
+		if needReconcile {
+			if err = c.reconcileBgpLbVipServiceLocked(key, svc); err != nil {
+				klog.Errorf("failed to reconcile bgp-lb-vip for service %s: %v", key, err)
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -390,6 +419,13 @@ func parseVipAddr(vip string) string {
 }
 
 func (c *Controller) handleAddService(key string) error {
+	if c.config.EnableBgpLbVip {
+		// enable-bgp-lb-vip and enable-lb-svc are mutually exclusive modes.
+		// When bgp-lb-vip is on, we handle the EIP binding and return; the LB-SVC
+		// pod-based flow is intentionally skipped.
+		klog.Infof("dispatch add service %s to bgp-lb-vip handler", key)
+		return c.handleAddBgpLbVipService(key)
+	}
 	if !c.config.EnableLbSvc {
 		return nil
 	}
@@ -571,5 +607,250 @@ func (c *Controller) checkServiceLBIPBelongToSubnet(svc *v1.Service) error {
 		return err
 	}
 
+	return nil
+}
+
+// handleAddBgpLbVipService binds a pre-allocated VIP (type=bgp_lb_vip) to a
+// LoadBalancer Service. The VIP is identified by the ovn.kubernetes.io/bgp-vip annotation.
+// Once bound:
+//   - svc.spec.externalIPs is set so kube-proxy installs DNAT rules on every node.
+//   - svc.status.loadBalancer.ingress is set so the BGP speaker announces the IP.
+//   - svc.annotations[ovn.kubernetes.io/bgp] is set to "true" so the speaker picks it up.
+func (c *Controller) handleAddBgpLbVipService(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.Error(err)
+		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	c.svcKeyMutex.LockKey(key)
+	defer func() { _ = c.svcKeyMutex.UnlockKey(key) }()
+
+	svc, err := c.servicesLister.Services(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Error(err)
+		return err
+	}
+	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+		return nil
+	}
+
+	return c.reconcileBgpLbVipServiceLocked(key, svc)
+}
+
+func (c *Controller) reconcileBgpLbVipServiceLocked(key string, svc *v1.Service) error {
+	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+		return nil
+	}
+
+	vipName := svc.Annotations[util.BgpVipAnnotation]
+	if vipName == "" {
+		// Service does not request a BGP LB VIP; nothing to do.
+		return nil
+	}
+
+	namespace, name := svc.Namespace, svc.Name
+
+	klog.Infof("handle add bgp-lb-vip service %s, vip %s", key, vipName)
+	klog.Infof("bgp-lb-vip service %s current state: externalIPs=%v ingress=%v bgp=%q", key, svc.Spec.ExternalIPs, svc.Status.LoadBalancer.Ingress, svc.Annotations[util.BgpAnnotation])
+
+	vip, err := c.virtualIpsLister.Get(vipName)
+	if err != nil {
+		klog.Errorf("failed to get vip %s for service %s: %v", vipName, key, err)
+		return err
+	}
+	// Only bgp_lb_vip is supported here because this path expects an IPAM-only VIP
+	// that is written into Service externalIPs/ingress for speaker announcement.
+	if vip.Spec.Type != util.BgpLbVip {
+		return fmt.Errorf("vip %s has type %q, expected %q", vipName, vip.Spec.Type, util.BgpLbVip)
+	}
+	if vip.Status.V4ip == "" {
+		return fmt.Errorf("vip %s has no IP allocated yet", vipName)
+	}
+
+	vipIP := vip.Status.V4ip
+	klog.Infof("bgp-lb-vip service %s resolved vip %s to ip %s", key, vipName, vipIP)
+
+	targetSvc := svc.DeepCopy()
+	if targetSvc.Annotations == nil {
+		targetSvc.Annotations = make(map[string]string)
+	}
+
+	// Set externalIPs so kube-proxy installs DNAT rules on every node.
+	// Use replace semantics: desired state is exactly [vipIP].
+	desiredExternalIPs := []string{vipIP}
+	// Also ensure the BGP speaker annotation is present so collectSvcBgpPrefixes announces the IP.
+	changed := !equality.Semantic.DeepEqual(svc.Spec.ExternalIPs, desiredExternalIPs) ||
+		svc.Annotations[util.BgpAnnotation] != "true"
+	baseSvc := svc
+	if changed {
+		klog.Infof("bgp-lb-vip service %s updating spec: externalIPs %v -> %v, bgp %q -> %q", key, svc.Spec.ExternalIPs, desiredExternalIPs, svc.Annotations[util.BgpAnnotation], "true")
+		targetSvc.Annotations[util.BgpAnnotation] = "true"
+		targetSvc.Spec.ExternalIPs = desiredExternalIPs
+		updatedSvc, updateErr := c.config.KubeClient.CoreV1().Services(namespace).Update(
+			context.Background(), targetSvc, metav1.UpdateOptions{},
+		)
+		if updateErr != nil {
+			klog.Errorf("failed to update service %s/%s: %v", namespace, name, updateErr)
+			return updateErr
+		}
+		klog.Infof("bgp-lb-vip service %s spec updated successfully", key)
+		baseSvc = updatedSvc
+		targetSvc = updatedSvc.DeepCopy()
+	}
+
+	// Set status.loadBalancer.ingress so the BGP speaker discovers the IP.
+	ingress := []v1.LoadBalancerIngress{{IP: vipIP}}
+	if !equality.Semantic.DeepEqual(baseSvc.Status.LoadBalancer.Ingress, ingress) {
+		klog.Infof("bgp-lb-vip service %s updating status ingress: %v -> %v", key, baseSvc.Status.LoadBalancer.Ingress, ingress)
+		targetSvc.Status.LoadBalancer.Ingress = ingress
+		if _, err = c.config.KubeClient.CoreV1().Services(namespace).UpdateStatus(
+			context.Background(), targetSvc, metav1.UpdateOptions{},
+		); err != nil {
+			klog.Errorf("failed to update status for service %s/%s: %v", namespace, name, err)
+			return err
+		}
+		klog.Infof("bgp-lb-vip service %s status updated successfully", key)
+	}
+
+	klog.Infof("bgp-lb-vip service %s bound to vip %s (%s)", key, vipName, vipIP)
+	return nil
+}
+
+func (c *Controller) needReconcileBgpLbVipService(svc *v1.Service) (bool, error) {
+	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+		return false, nil
+	}
+	vipName := svc.Annotations[util.BgpVipAnnotation]
+	if vipName == "" {
+		return false, nil
+	}
+	key := cache.MetaObjectToName(svc).String()
+
+	vip, err := c.virtualIpsLister.Get(vipName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// VIP does not exist yet (or has already been deleted). There is nothing to
+			// reconcile now. When the VIP is eventually created and receives its IP, the
+			// VIP update event will re-enqueue this Service via enqueueUpdateVirtualIP's
+			// indexer logic (Issue 1 fix). Returning (true, nil) here would only trigger
+			// a pointless reconcile that fails with NotFound and causes retry log noise.
+			klog.Infof("bgp-lb-vip service %s: vip %s not found, skip reconcile", key, vipName)
+			return false, nil
+		}
+		return false, err
+	}
+
+	if vip.Spec.Type != util.BgpLbVip || vip.Status.V4ip == "" {
+		klog.Infof("bgp-lb-vip service %s needs reconcile: vip %s type=%q v4ip=%q", key, vipName, vip.Spec.Type, vip.Status.V4ip)
+		return true, nil
+	}
+
+	desiredExternalIPs := []string{vip.Status.V4ip}
+	desiredIngress := []v1.LoadBalancerIngress{{IP: vip.Status.V4ip}}
+
+	if !equality.Semantic.DeepEqual(svc.Spec.ExternalIPs, desiredExternalIPs) {
+		klog.Infof("bgp-lb-vip service %s needs reconcile: externalIPs=%v desired=%v", key, svc.Spec.ExternalIPs, desiredExternalIPs)
+		return true, nil
+	}
+	if svc.Annotations[util.BgpAnnotation] != "true" {
+		klog.Infof("bgp-lb-vip service %s needs reconcile: bgp annotation=%q desired=%q", key, svc.Annotations[util.BgpAnnotation], "true")
+		return true, nil
+	}
+	if !equality.Semantic.DeepEqual(svc.Status.LoadBalancer.Ingress, desiredIngress) {
+		klog.Infof("bgp-lb-vip service %s needs reconcile: ingress=%v desired=%v", key, svc.Status.LoadBalancer.Ingress, desiredIngress)
+		return true, nil
+	}
+
+	klog.Infof("bgp-lb-vip service %s does not need reconcile", key)
+	return false, nil
+}
+
+func (c *Controller) needCleanupBgpLbVipServiceBinding(svc *v1.Service) bool {
+	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+		return false
+	}
+	if svc.Annotations[util.BgpVipAnnotation] != "" {
+		return false
+	}
+	if svc.Annotations[util.BgpAnnotation] == "true" {
+		return true
+	}
+	return len(svc.Status.LoadBalancer.Ingress) != 0
+}
+
+func (c *Controller) cleanupBgpLbVipServiceBindingByVip(vipName string) error {
+	svcs, err := c.servicesLister.Services(v1.NamespaceAll).List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list services for bgp-lb-vip %s cleanup: %v", vipName, err)
+		return err
+	}
+
+	for _, svc := range svcs {
+		if len(svc.Annotations) == 0 || svc.Annotations[util.BgpVipAnnotation] != vipName {
+			continue
+		}
+		if err := c.cleanupBgpLbVipServiceBinding(svc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) cleanupBgpLbVipServiceBinding(svc *v1.Service) error {
+	targetSvc := svc.DeepCopy()
+	if targetSvc.Annotations == nil {
+		targetSvc.Annotations = make(map[string]string)
+	}
+
+	// Only clear fields owned by the controller: spec.externalIPs and the BGP
+	// speaker annotation. Do NOT remove BgpVipAnnotation — that is a user-managed
+	// field. If the VIP is re-created with the same name the Service must be able
+	// to auto-rebind via the still-present annotation.
+	specChanged := len(svc.Spec.ExternalIPs) != 0 ||
+		svc.Annotations[util.BgpAnnotation] != ""
+
+	if specChanged {
+		targetSvc.Spec.ExternalIPs = nil
+		delete(targetSvc.Annotations, util.BgpAnnotation)
+
+		updatedSvc, err := c.config.KubeClient.CoreV1().Services(targetSvc.Namespace).Update(
+			context.Background(), targetSvc, metav1.UpdateOptions{},
+		)
+		if err != nil {
+			klog.Errorf("failed to cleanup service %s/%s spec for bgp-lb-vip: %v", svc.Namespace, svc.Name, err)
+			return err
+		}
+		targetSvc = updatedSvc.DeepCopy()
+	}
+
+	if len(svc.Status.LoadBalancer.Ingress) != 0 {
+		targetSvc.Status.LoadBalancer.Ingress = nil
+		if _, err := c.config.KubeClient.CoreV1().Services(targetSvc.Namespace).UpdateStatus(
+			context.Background(), targetSvc, metav1.UpdateOptions{},
+		); err != nil {
+			klog.Errorf("failed to cleanup service %s/%s status for bgp-lb-vip: %v", svc.Namespace, svc.Name, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanBgpLbVipService is called on Service deletion.
+// The VIP CR lifecycle is managed independently by the user; no action needed here.
+func (c *Controller) cleanBgpLbVipService(svc *v1.Service) error {
+	if len(svc.Spec.ExternalIPs) == 0 && len(svc.Status.LoadBalancer.Ingress) == 0 {
+		return nil
+	}
+	klog.Infof("clean bgp-lb-vip for deleted service %s/%s", svc.Namespace, svc.Name)
+	// The Service object is being deleted, so kube-proxy will remove Service-related
+	// forwarding state from the deleted Service spec/status. The VIP CR is managed
+	// separately and remains reusable by another Service.
 	return nil
 }

--- a/pkg/controller/service_test.go
+++ b/pkg/controller/service_test.go
@@ -1,12 +1,18 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/keymutex"
 
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnfake "github.com/kubeovn/kube-ovn/pkg/client/clientset/versioned/fake"
+	kubeovninformerfactory "github.com/kubeovn/kube-ovn/pkg/client/informers/externalversions"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -141,4 +147,458 @@ func Test_getVipIps(t *testing.T) {
 			require.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+// newBgpLbVipController creates a minimal controller wired for handleAddBgpLbVipService tests.
+func newBgpLbVipController(t *testing.T, vip *kubeovnv1.Vip, svc *v1.Service) *Controller {
+	t.Helper()
+
+	fc, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+
+	// Wire virtualIpsLister from a dedicated informer factory.
+	kubeovnClient := kubeovnfake.NewSimpleClientset()
+	if vip != nil {
+		_, err = kubeovnClient.KubeovnV1().Vips().Create(context.Background(), vip, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	vipInformerFactory := kubeovninformerfactory.NewSharedInformerFactoryWithOptions(kubeovnClient, 0)
+	vipInformer := vipInformerFactory.Kubeovn().V1().Vips()
+	vipInformerFactory.Start(stopCh)
+	vipInformerFactory.WaitForCacheSync(stopCh)
+
+	ctrl.virtualIpsLister = vipInformer.Lister()
+	ctrl.svcKeyMutex = keymutex.NewHashed(0)
+
+	// Seed service into the services lister cache.
+	if svc != nil {
+		err = fc.fakeInformers.serviceInformer.Informer().GetIndexer().Add(svc)
+		require.NoError(t, err)
+	}
+
+	// Also register VIP in the indexer so the lister can find it immediately.
+	if vip != nil {
+		err = vipInformer.Informer().GetIndexer().Add(vip)
+		require.NoError(t, err)
+	}
+
+	ctrl.config.KubeClient = fc.fakeController.config.KubeClient
+	if svc != nil {
+		_, err = ctrl.config.KubeClient.CoreV1().Services(svc.Namespace).Create(
+			context.Background(), svc, metav1.CreateOptions{})
+		if err != nil {
+			// already exists from fake construction — ignore
+			_ = err
+		}
+	}
+
+	return ctrl
+}
+
+func TestHandleAddBgpLbVipService(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ns      = metav1.NamespaceDefault
+		svcName = "my-lb-svc"
+		vipName = "my-lb-vip"
+		vipIP   = "203.0.113.5"
+	)
+
+	readyVIP := func() *kubeovnv1.Vip {
+		return &kubeovnv1.Vip{
+			ObjectMeta: metav1.ObjectMeta{Name: vipName},
+			Spec: kubeovnv1.VipSpec{
+				Type:   util.BgpLbVip,
+				Subnet: "external",
+			},
+			Status: kubeovnv1.VipStatus{V4ip: vipIP},
+		}
+	}
+
+	lbSvc := func(annotation string) *v1.Service {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcName,
+				Namespace: ns,
+			},
+			Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		}
+		if annotation != "" {
+			svc.Annotations = map[string]string{util.BgpVipAnnotation: annotation}
+		}
+		return svc
+	}
+
+	key := cache.MetaObjectToName(lbSvc(vipName)).String()
+
+	t.Run("no annotation: noop", func(t *testing.T) {
+		t.Parallel()
+		ctrl := newBgpLbVipController(t, readyVIP(), lbSvc(""))
+		require.NoError(t, ctrl.handleAddBgpLbVipService(key))
+	})
+
+	t.Run("non-LB service type: noop", func(t *testing.T) {
+		t.Parallel()
+		svc := lbSvc(vipName)
+		svc.Spec.Type = v1.ServiceTypeClusterIP
+		ctrl := newBgpLbVipController(t, readyVIP(), svc)
+		require.NoError(t, ctrl.handleAddBgpLbVipService(key))
+	})
+
+	t.Run("vip not found: error returned", func(t *testing.T) {
+		t.Parallel()
+		ctrl := newBgpLbVipController(t, nil, lbSvc("nonexistent-vip"))
+		err := ctrl.handleAddBgpLbVipService(key)
+		require.Error(t, err)
+	})
+
+	t.Run("vip wrong type: error returned", func(t *testing.T) {
+		t.Parallel()
+		vip := readyVIP()
+		vip.Spec.Type = util.SwitchLBRuleVip // wrong type
+		ctrl := newBgpLbVipController(t, vip, lbSvc(vipName))
+		err := ctrl.handleAddBgpLbVipService(key)
+		require.Error(t, err)
+	})
+
+	t.Run("vip has no IP yet: error returned", func(t *testing.T) {
+		t.Parallel()
+		vip := readyVIP()
+		vip.Status.V4ip = ""
+		ctrl := newBgpLbVipController(t, vip, lbSvc(vipName))
+		err := ctrl.handleAddBgpLbVipService(key)
+		require.Error(t, err)
+	})
+
+	t.Run("happy path: externalIPs, ingress, and bgp annotation set", func(t *testing.T) {
+		t.Parallel()
+		ctrl := newBgpLbVipController(t, readyVIP(), lbSvc(vipName))
+		require.NoError(t, ctrl.handleAddBgpLbVipService(key))
+
+		updated, err := ctrl.config.KubeClient.CoreV1().Services(ns).Get(
+			context.Background(), svcName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Contains(t, updated.Spec.ExternalIPs, vipIP)
+		require.Equal(t, []v1.LoadBalancerIngress{{IP: vipIP}}, updated.Status.LoadBalancer.Ingress)
+		require.Equal(t, "true", updated.Annotations[util.BgpAnnotation])
+	})
+
+	t.Run("idempotent: second call is a noop", func(t *testing.T) {
+		t.Parallel()
+		ctrl := newBgpLbVipController(t, readyVIP(), lbSvc(vipName))
+		require.NoError(t, ctrl.handleAddBgpLbVipService(key))
+		require.NoError(t, ctrl.handleAddBgpLbVipService(key))
+	})
+}
+
+func TestReconcileBgpLbVipServiceLocked(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ns      = metav1.NamespaceDefault
+		svcName = "my-lb-svc"
+		vipName = "my-lb-vip"
+		vipIP   = "203.0.113.5"
+	)
+
+	vip := &kubeovnv1.Vip{
+		ObjectMeta: metav1.ObjectMeta{Name: vipName},
+		Spec: kubeovnv1.VipSpec{
+			Type:   util.BgpLbVip,
+			Subnet: "external",
+		},
+		Status: kubeovnv1.VipStatus{V4ip: vipIP},
+	}
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: ns,
+			Annotations: map[string]string{
+				util.BgpVipAnnotation: vipName,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type:        v1.ServiceTypeLoadBalancer,
+			ExternalIPs: []string{"198.51.100.9"},
+		},
+	}
+
+	ctrl := newBgpLbVipController(t, vip, svc)
+	key := cache.MetaObjectToName(svc).String()
+
+	require.NoError(t, ctrl.reconcileBgpLbVipServiceLocked(key, svc))
+
+	updated, err := ctrl.config.KubeClient.CoreV1().Services(ns).Get(
+		context.Background(), svcName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{vipIP}, updated.Spec.ExternalIPs)
+	require.Equal(t, []v1.LoadBalancerIngress{{IP: vipIP}}, updated.Status.LoadBalancer.Ingress)
+	require.Equal(t, "true", updated.Annotations[util.BgpAnnotation])
+}
+
+func TestNeedReconcileBgpLbVipService(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ns      = metav1.NamespaceDefault
+		svcName = "my-lb-svc"
+		vipName = "my-lb-vip"
+		vipIP   = "203.0.113.5"
+	)
+
+	newVIP := func(name string) *kubeovnv1.Vip {
+		return &kubeovnv1.Vip{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kubeovnv1.VipSpec{
+				Type:   util.BgpLbVip,
+				Subnet: "external",
+			},
+			Status: kubeovnv1.VipStatus{V4ip: vipIP},
+		}
+	}
+
+	newSvc := func(withBgpVip bool) *v1.Service {
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcName,
+				Namespace: ns,
+			},
+			Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		}
+		if withBgpVip {
+			svc.Annotations = map[string]string{util.BgpVipAnnotation: vipName}
+		}
+		return svc
+	}
+
+	t.Run("service without bgp-vip annotation does not reconcile", func(t *testing.T) {
+		t.Parallel()
+		ctrl := newBgpLbVipController(t, newVIP(vipName), newSvc(false))
+		need, err := ctrl.needReconcileBgpLbVipService(newSvc(false))
+		require.NoError(t, err)
+		require.False(t, need)
+	})
+
+	t.Run("already converged service does not reconcile", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(true)
+		svc.Annotations[util.BgpAnnotation] = "true"
+		svc.Spec.ExternalIPs = []string{vipIP}
+		svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: vipIP}}
+		ctrl := newBgpLbVipController(t, newVIP(vipName), svc)
+		need, err := ctrl.needReconcileBgpLbVipService(svc)
+		require.NoError(t, err)
+		require.False(t, need)
+	})
+
+	t.Run("drifted externalIPs requires reconcile", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(true)
+		svc.Annotations[util.BgpAnnotation] = "true"
+		svc.Spec.ExternalIPs = []string{"198.51.100.9"}
+		svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: vipIP}}
+		ctrl := newBgpLbVipController(t, newVIP(vipName), svc)
+		need, err := ctrl.needReconcileBgpLbVipService(svc)
+		require.NoError(t, err)
+		require.True(t, need)
+	})
+
+	t.Run("missing vip skips reconcile", func(t *testing.T) {
+		// When the VIP CR does not exist yet (or has been deleted), there is nothing
+		// to reconcile. The controller must NOT return (true, nil) here: doing so
+		// would trigger reconcileBgpLbVipServiceLocked immediately, which would fail
+		// with NotFound and be re-queued indefinitely until the VIP appears.
+		// Instead we return (false, nil) and rely on enqueueUpdateVirtualIP's indexer
+		// logic to re-enqueue the Service once the VIP gets its IP.
+		t.Parallel()
+		svc := newSvc(true)
+		ctrl := newBgpLbVipController(t, nil, svc)
+		need, err := ctrl.needReconcileBgpLbVipService(svc)
+		require.NoError(t, err)
+		require.False(t, need)
+	})
+}
+
+func TestNeedCleanupBgpLbVipServiceBinding(t *testing.T) {
+	t.Parallel()
+
+	ctrl := &Controller{}
+	makeService := func() *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "lb-svc",
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
+		}
+	}
+
+	t.Run("service with bgp-vip annotation is not cleaned", func(t *testing.T) {
+		t.Parallel()
+		svc := makeService()
+		svc.Annotations = map[string]string{util.BgpVipAnnotation: "vip-a", util.BgpAnnotation: "true"}
+		require.False(t, ctrl.needCleanupBgpLbVipServiceBinding(svc))
+	})
+
+	t.Run("service with stale bgp annotation is cleaned", func(t *testing.T) {
+		t.Parallel()
+		svc := makeService()
+		svc.Annotations = map[string]string{util.BgpAnnotation: "true"}
+		svc.Spec.ExternalIPs = []string{"203.0.113.10"}
+		require.True(t, ctrl.needCleanupBgpLbVipServiceBinding(svc))
+	})
+
+	t.Run("service with stale ingress is cleaned", func(t *testing.T) {
+		t.Parallel()
+		svc := makeService()
+		svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: "203.0.113.10"}}
+		require.True(t, ctrl.needCleanupBgpLbVipServiceBinding(svc))
+	})
+
+	t.Run("service without managed state is not cleaned", func(t *testing.T) {
+		t.Parallel()
+		svc := makeService()
+		require.False(t, ctrl.needCleanupBgpLbVipServiceBinding(svc))
+	})
+
+	t.Run("non loadbalancer service is not cleaned", func(t *testing.T) {
+		t.Parallel()
+		svc := makeService()
+		svc.Spec.Type = v1.ServiceTypeClusterIP
+		svc.Annotations = map[string]string{util.BgpAnnotation: "true"}
+		require.False(t, ctrl.needCleanupBgpLbVipServiceBinding(svc))
+	})
+}
+
+func TestCleanupBgpLbVipServiceBindingByVip(t *testing.T) {
+	t.Parallel()
+
+	fc, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	ctrl := fc.fakeController
+
+	const ns = metav1.NamespaceDefault
+	bindingSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-bound",
+			Namespace: ns,
+			Annotations: map[string]string{
+				util.BgpVipAnnotation: "vip-a",
+				util.BgpAnnotation:    "true",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type:        v1.ServiceTypeLoadBalancer,
+			ExternalIPs: []string{"203.0.113.10"},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{IP: "203.0.113.10"}},
+			},
+		},
+	}
+	unrelatedSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-other",
+			Namespace: ns,
+			Annotations: map[string]string{
+				util.BgpVipAnnotation: "vip-b",
+				util.BgpAnnotation:    "true",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type:        v1.ServiceTypeLoadBalancer,
+			ExternalIPs: []string{"203.0.113.11"},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{IP: "203.0.113.11"}},
+			},
+		},
+	}
+
+	for _, svc := range []*v1.Service{bindingSvc, unrelatedSvc} {
+		err = fc.fakeInformers.serviceInformer.Informer().GetIndexer().Add(svc)
+		require.NoError(t, err)
+		_, err = ctrl.config.KubeClient.CoreV1().Services(ns).Create(context.Background(), svc, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, ctrl.cleanupBgpLbVipServiceBindingByVip("vip-a"))
+
+	cleaned, err := ctrl.config.KubeClient.CoreV1().Services(ns).Get(context.Background(), bindingSvc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Empty(t, cleaned.Spec.ExternalIPs)
+	require.Empty(t, cleaned.Status.LoadBalancer.Ingress)
+	require.Empty(t, cleaned.Annotations[util.BgpAnnotation])
+	// BgpVipAnnotation is a user-managed field; cleanupBgpLbVipServiceBinding must
+	// NOT remove it so the Service can auto-rebind if the VIP is re-created.
+	require.Equal(t, "vip-a", cleaned.Annotations[util.BgpVipAnnotation])
+
+	stillBound, err := ctrl.config.KubeClient.CoreV1().Services(ns).Get(context.Background(), unrelatedSvc.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"203.0.113.11"}, stillBound.Spec.ExternalIPs)
+	require.Equal(t, []v1.LoadBalancerIngress{{IP: "203.0.113.11"}}, stillBound.Status.LoadBalancer.Ingress)
+	require.Equal(t, "vip-b", stillBound.Annotations[util.BgpVipAnnotation])
+}
+
+func TestHandleAddServicePrefersBgpLbVipWhenBothEnabled(t *testing.T) {
+	t.Parallel()
+
+	newService := func() *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "lb-svc",
+				Namespace: metav1.NamespaceDefault,
+				Annotations: map[string]string{
+					util.AttachmentProvider: "default/provider",
+				},
+			},
+			Spec: v1.ServiceSpec{
+				Type: v1.ServiceTypeLoadBalancer,
+				Ports: []v1.ServicePort{{
+					Name:     "tcp",
+					Protocol: v1.ProtocolTCP,
+					Port:     80,
+				}},
+			},
+		}
+	}
+
+	t.Run("both enabled uses bgp path and returns noop without bgp-vip annotation", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, nil)
+		require.NoError(t, err)
+
+		ctrl := fc.fakeController
+		ctrl.svcKeyMutex = keymutex.NewHashed(0)
+		ctrl.config.EnableBgpLbVip = true
+		ctrl.config.EnableLbSvc = true
+
+		svc := newService()
+		require.NoError(t, fc.fakeInformers.serviceInformer.Informer().GetIndexer().Add(svc))
+
+		key := cache.MetaObjectToName(svc).String()
+		require.NoError(t, ctrl.handleAddService(key))
+	})
+
+	t.Run("only lb-svc enabled enters lb-svc path and errors without NAD", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, nil)
+		require.NoError(t, err)
+
+		ctrl := fc.fakeController
+		ctrl.svcKeyMutex = keymutex.NewHashed(0)
+		ctrl.config.EnableBgpLbVip = false
+		ctrl.config.EnableLbSvc = true
+
+		svc := newService()
+		require.NoError(t, fc.fakeInformers.serviceInformer.Informer().GetIndexer().Add(svc))
+
+		key := cache.MetaObjectToName(svc).String()
+		require.Error(t, ctrl.handleAddService(key))
+	})
 }

--- a/pkg/controller/vip.go
+++ b/pkg/controller/vip.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	v1 "k8s.io/api/core/v1"
+
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovs"
 	"github.com/kubeovn/kube-ovn/pkg/util"
@@ -42,6 +44,33 @@ func (c *Controller) enqueueUpdateVirtualIP(oldObj, newObj any) {
 	if !slices.Equal(oldVip.Spec.Selector, newVip.Spec.Selector) {
 		klog.Infof("enqueue update virtual parents for %s", key)
 		c.updateVirtualParentsQueue.Add(key)
+	}
+	// When a bgp_lb_vip gets its IP for the first time (status.V4ip: "" → non-empty),
+	// actively re-enqueue any Services that reference this VIP so they bind immediately
+	// instead of waiting for the next retry backoff interval.
+	// The informer calls UpdateFunc for all updates including status-only ones, so this
+	// handler fires whenever the VIP object is modified. The spec-change block above only
+	// enqueues to updateVirtualIPQueue on Spec field changes; this block is independent
+	// and fires on any update where oldVip.Status.V4ip was empty and newVip.Status.V4ip
+	// is now set (the first IP allocation event).
+	if c.config.EnableBgpLbVip &&
+		newVip.Spec.Type == util.BgpLbVip &&
+		oldVip.Status.V4ip == "" && newVip.Status.V4ip != "" {
+		// Use the bgpVipIndexName indexer for O(k) lookup instead of a full Service list scan.
+		objs, err := c.svcByBgpVipIndexer.ByIndex(bgpVipIndexName, newVip.Name)
+		if err != nil {
+			klog.Errorf("failed to index services for vip %s re-enqueue: %v", newVip.Name, err)
+			return
+		}
+		for _, obj := range objs {
+			svc, ok := obj.(*v1.Service)
+			if !ok {
+				continue
+			}
+			svcKey := cache.MetaObjectToName(svc).String()
+			klog.Infof("re-enqueue service %s: vip %s got IP %s", svcKey, newVip.Name, newVip.Status.V4ip)
+			c.addServiceQueue.Add(svcKey)
+		}
 	}
 }
 
@@ -93,7 +122,10 @@ func (c *Controller) handleAddVirtualIP(key string) error {
 		klog.Errorf("failed to get subnet %s: %v", subnetName, err)
 		return err
 	}
-	portName := ovs.PodNameToPortName(vip.Name, vip.Spec.Namespace, subnet.Spec.Provider)
+	ipamKey := vip.Name
+	if vip.Spec.Type != util.BgpLbVip {
+		ipamKey = ovs.PodNameToPortName(vip.Name, vip.Spec.Namespace, subnet.Spec.Provider)
+	}
 	sourceV4Ip = vip.Spec.V4ip
 	sourceV6Ip = vip.Spec.V6ip
 	// v6 ip address can not use upper case
@@ -108,15 +140,29 @@ func (c *Controller) handleAddVirtualIP(key string) error {
 		if vip.Spec.MacAddress != "" {
 			macPointer = &vip.Spec.MacAddress
 		}
-		v4ip, v6ip, mac, err = c.acquireStaticIPAddress(subnet.Name, vip.Name, portName, ipStr, macPointer)
+		v4ip, v6ip, mac, err = c.acquireStaticIPAddress(subnet.Name, vip.Name, ipamKey, ipStr, macPointer)
 	} else {
 		// Random allocate
-		v4ip, v6ip, mac, err = c.acquireIPAddress(subnet.Name, vip.Name, portName)
+		v4ip, v6ip, mac, err = c.acquireIPAddress(subnet.Name, vip.Name, ipamKey)
 	}
 	if err != nil {
 		klog.Error(err)
 		return err
 	}
+	// bgp_lb_vip: IPAM-only VIP — no OVN LSP, no virtual parents.
+	// The IP is set in status.loadBalancer.ingress by the service controller,
+	// and announced by the BGP speaker via the ovn.kubernetes.io/bgp annotation.
+	if vip.Spec.Type == util.BgpLbVip {
+		if err = c.createOrUpdateVipCR(key, vip.Spec.Namespace, subnet.Name, v4ip, v6ip, mac); err != nil {
+			klog.Errorf("failed to create or update bgp-lb vip '%s': %v", vip.Name, err)
+			return err
+		}
+		c.updateSubnetStatusQueue.Add(subnetName)
+		return nil
+	}
+
+	portName := ipamKey
+
 	if vip.Spec.Type == util.SwitchLBRuleVip {
 		// create a lsp use subnet gw mac, and set it option as arp_proxy
 		lrpName := fmt.Sprintf("%s-%s", subnet.Spec.Vpc, subnet.Name)
@@ -189,25 +235,42 @@ func (c *Controller) handleUpdateVirtualIP(key string) error {
 	// should delete
 	if !vip.DeletionTimestamp.IsZero() {
 		klog.Infof("handle deleting vip %s", vip.Name)
-		// Clean up resources before removing finalizer
-		if vip.Spec.Type != "" {
-			subnet, err := c.subnetsLister.Get(vip.Spec.Subnet)
-			if err != nil {
-				klog.Errorf("failed to get subnet %s: %v", vip.Spec.Subnet, err)
-				return err
-			}
-			portName := ovs.PodNameToPortName(vip.Name, vip.Spec.Namespace, subnet.Spec.Provider)
-			klog.Infof("delete vip lsp %s", portName)
-			if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
-				err = fmt.Errorf("failed to delete lsp %s: %w", vip.Name, err)
-				klog.Error(err)
+		if vip.Spec.Type == util.BgpLbVip {
+			if err := c.cleanupBgpLbVipServiceBindingByVip(vip.Name); err != nil {
+				klog.Errorf("failed to cleanup bound services for bgp-lb-vip %s: %v", vip.Name, err)
 				return err
 			}
 		}
-		// delete virtual ports
-		if err := c.OVNNbClient.DeleteLogicalSwitchPort(vip.Name); err != nil {
-			klog.Errorf("delete virtual logical switch port %s from logical switch %s: %v", vip.Name, vip.Spec.Subnet, err)
-			return err
+		// bgp_lb_vip holds no OVN LSP; skip all OVN cleanup.
+		if vip.Spec.Type != util.BgpLbVip {
+			// Clean up resources before removing finalizer
+			switch vip.Spec.Type {
+			case util.SwitchLBRuleVip, util.KubeHostVMVip:
+				subnet, err := c.subnetsLister.Get(vip.Spec.Subnet)
+				if err != nil {
+					klog.Errorf("failed to get subnet %s: %v", vip.Spec.Subnet, err)
+					return err
+				}
+				portName := ovs.PodNameToPortName(vip.Name, vip.Spec.Namespace, subnet.Spec.Provider)
+				klog.Infof("delete vip lsp %s", portName)
+				if err := c.OVNNbClient.DeleteLogicalSwitchPort(portName); err != nil {
+					err = fmt.Errorf("failed to delete lsp %s: %w", vip.Name, err)
+					klog.Error(err)
+					return err
+				}
+
+				if vip.Spec.Type == util.SwitchLBRuleVip || vip.Spec.Type == util.KubeHostVMVip {
+					if err := c.OVNNbClient.DeleteLogicalSwitchPort(vip.Name); err != nil {
+						klog.Errorf("delete virtual logical switch port %s from logical switch %s: %v", vip.Name, vip.Spec.Subnet, err)
+						return err
+					}
+				}
+			default:
+				if err := c.OVNNbClient.DeleteLogicalSwitchPort(vip.Name); err != nil {
+					klog.Errorf("delete virtual logical switch port %s from logical switch %s: %v", vip.Name, vip.Spec.Subnet, err)
+					return err
+				}
+			}
 		}
 		// Release IP from IPAM before removing finalizer
 		c.ipam.ReleaseAddressByPod(vip.Name, vip.Spec.Subnet)
@@ -254,6 +317,7 @@ func (c *Controller) handleUpdateVirtualIP(key string) error {
 		klog.Errorf("failed to handle vip finalizer %v", err)
 		return err
 	}
+
 	return nil
 }
 
@@ -283,6 +347,10 @@ func (c *Controller) handleUpdateVirtualParents(key string) error {
 	if cachedVip.Spec.Type == util.KubeHostVMVip {
 		// vm use the vip as its real ip
 		klog.Infof("created host network pod vm ip %s", key)
+		return nil
+	}
+	if cachedVip.Spec.Type == util.BgpLbVip {
+		// bgp_lb_vip holds no OVN virtual port
 		return nil
 	}
 	// only pods in the same namespace as vip are allowed to use aap

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -51,6 +51,7 @@ type Configuration struct {
 	HoldTime                    float64
 	BgpServer                   *gobgp.BgpServer
 	AnnounceClusterIP           bool
+	EnableLbSvcAnnounce         bool
 	GracefulRestart             bool
 	GracefulRestartDeferralTime time.Duration
 	GracefulRestartTime         time.Duration
@@ -75,6 +76,7 @@ func ParseFlags() (*Configuration, error) {
 		argGracefulRestartDeferralTime = pflag.Duration("graceful-restart-deferral-time", DefaultGracefulRestartDeferralTime, "BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h.")
 		argGracefulRestart             = pflag.BoolP("graceful-restart", "", false, "Enables the BGP Graceful Restart so that routes are preserved on unexpected restarts")
 		argAnnounceClusterIP           = pflag.BoolP("announce-cluster-ip", "", false, "The Cluster IP of the service to announce to the BGP peers.")
+		argEnableLbSvcAnnounce         = pflag.BoolP("enable-lb-svc-announce", "", false, "Whether to announce LoadBalancer Service ingress IPs bound by ovn.kubernetes.io/bgp-vip.")
 		argGrpcHost                    = pflag.IP("grpc-host", net.IP{127, 0, 0, 1}, "The host address for grpc to listen, default: 127.0.0.1")
 		argGrpcPort                    = pflag.Int32("grpc-port", DefaultBGPGrpcPort, "The port for grpc to listen, default:50051")
 		argClusterAs                   = pflag.Uint32("cluster-as", 0, "The AS number of the local BGP speaker (required)")
@@ -138,6 +140,7 @@ func ParseFlags() (*Configuration, error) {
 
 	config := &Configuration{
 		AnnounceClusterIP:     *argAnnounceClusterIP,
+		EnableLbSvcAnnounce:   *argEnableLbSvcAnnounce,
 		GrpcHost:              *argGrpcHost,
 		GrpcPort:              *argGrpcPort,
 		ClusterAs:             *argClusterAs,

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -93,6 +93,16 @@ func (c *Controller) syncSubnetRoutes() {
 
 	collectPodExpectedPrefixes(pods, subnetByName, c.config.NodeName, bgpExpected)
 
+	if c.config.EnableLbSvcAnnounce {
+		// Announce LoadBalancer Service external IPs only for Services bound to bgp-vip.
+		services, err := c.servicesLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to list services for bgp-lb-eip, %v", err)
+			return
+		}
+		collectSvcBgpPrefixes(services, c.config.NodeName, bgpExpected)
+	}
+
 	if err := c.reconcileRoutes(bgpExpected); err != nil {
 		klog.Errorf("failed to reconcile routes: %s", err.Error())
 	}
@@ -145,6 +155,44 @@ func collectPodExpectedPrefixes(pods []*corev1.Pod, subnetByName map[string]*kub
 						addExpectedPrefix(strings.TrimSpace(ip), bgpExpected)
 					}
 				}
+			}
+		}
+	}
+}
+
+// collectSvcBgpPrefixes announces external IPs of LoadBalancer Services that carry
+// the ovn.kubernetes.io/bgp annotation and have a non-empty status.loadBalancer.ingress.
+// This is the speaker-side of the enable-bgp-lb-vip feature.
+//
+// Policy semantics:
+//   - "true" / "cluster": all speaker nodes announce the IP.
+//   - "local": currently announces on all speaker nodes for Services.
+func collectSvcBgpPrefixes(services []*corev1.Service, _ string, bgpExpected prefixMap) {
+	for _, svc := range services {
+		if len(svc.Annotations) == 0 {
+			continue
+		}
+		if svc.Annotations[util.BgpVipAnnotation] == "" {
+			continue
+		}
+		policy := svc.Annotations[util.BgpAnnotation]
+		if policy == "" {
+			continue
+		}
+		for _, ingress := range svc.Status.LoadBalancer.Ingress {
+			if ingress.IP == "" {
+				continue
+			}
+			switch policy {
+			case "true", announcePolicyCluster:
+				addExpectedPrefix(ingress.IP, bgpExpected)
+			case announcePolicyLocal:
+				// For LB Services the "local" policy announces on all nodes:
+				// there is no single pod node to pin to, and the external router
+				// performs ECMP over all BGP peers anyway.
+				addExpectedPrefix(ingress.IP, bgpExpected)
+			default:
+				klog.Warningf("service %s/%s: invalid bgp annotation value %q", svc.Namespace, svc.Name, policy)
 			}
 		}
 	}

--- a/pkg/speaker/subnet_test.go
+++ b/pkg/speaker/subnet_test.go
@@ -238,3 +238,114 @@ func TestCollectPodExpectedPrefixes(t *testing.T) {
 		})
 	}
 }
+
+func makeService(name, ns, bgpPolicy string, ingressIPs ...string) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+	}
+	if bgpPolicy != "" {
+		svc.Annotations = map[string]string{
+			util.BgpAnnotation:    bgpPolicy,
+			util.BgpVipAnnotation: "vip1",
+		}
+	}
+	for _, ip := range ingressIPs {
+		svc.Status.LoadBalancer.Ingress = append(
+			svc.Status.LoadBalancer.Ingress,
+			corev1.LoadBalancerIngress{IP: ip},
+		)
+	}
+	return svc
+}
+
+func TestCollectSvcBgpPrefixes(t *testing.T) {
+	cases := []struct {
+		name     string
+		services []*corev1.Service
+		wantIPs  []string
+		wantNot  []string
+	}{
+		{
+			name:     "no annotation: not announced",
+			services: []*corev1.Service{makeService("svc1", "default", "", "1.2.3.4")},
+			wantNot:  []string{"1.2.3.4/32"},
+		},
+		{
+			name: "bgp annotation without bgp-vip: not announced",
+			services: []*corev1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.BgpAnnotation: "true",
+					},
+				},
+				Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}}}},
+			}},
+			wantNot: []string{"1.2.3.4/32"},
+		},
+		{
+			name:     "bgp=true: announced",
+			services: []*corev1.Service{makeService("svc1", "default", "true", "1.2.3.4")},
+			wantIPs:  []string{"1.2.3.4/32"},
+		},
+		{
+			name:     "bgp=cluster: announced",
+			services: []*corev1.Service{makeService("svc1", "default", "cluster", "10.0.0.1")},
+			wantIPs:  []string{"10.0.0.1/32"},
+		},
+		{
+			name:     "bgp=local: announced on all nodes for LB service",
+			services: []*corev1.Service{makeService("svc1", "default", "local", "192.168.100.5")},
+			wantIPs:  []string{"192.168.100.5/32"},
+		},
+		{
+			name:     "no ingress IP: nothing announced",
+			services: []*corev1.Service{makeService("svc1", "default", "true")},
+			wantNot:  []string{},
+		},
+		{
+			name: "multiple services: each contributes independently",
+			services: []*corev1.Service{
+				makeService("svc1", "default", "true", "1.1.1.1"),
+				makeService("svc2", "default", "", "2.2.2.2"),
+				makeService("svc3", "default", "cluster", "3.3.3.3"),
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc4",
+						Namespace: "default",
+						Annotations: map[string]string{
+							util.BgpAnnotation: "cluster",
+						},
+					},
+					Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "4.4.4.4"}}}},
+				},
+			},
+			wantIPs: []string{"1.1.1.1/32", "3.3.3.3/32"},
+			wantNot: []string{"2.2.2.2/32", "4.4.4.4/32"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bgpExpected := make(prefixMap)
+			collectSvcBgpPrefixes(tc.services, "node1", bgpExpected)
+
+			for _, wantIP := range tc.wantIPs {
+				found := false
+				for _, prefixes := range bgpExpected {
+					if prefixes.Has(wantIP) {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "expected %s in bgpExpected, got %v", wantIP, bgpExpected)
+			}
+			for _, notIP := range tc.wantNot {
+				for _, prefixes := range bgpExpected {
+					require.False(t, prefixes.Has(notIP), "expected %s NOT in bgpExpected", notIP)
+				}
+			}
+		})
+	}
+}

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -16,15 +16,19 @@ const (
 	DeprecatedFinalizerName    = "kube-ovn-controller"
 	KubeOVNControllerFinalizer = "kubeovn.io/kube-ovn-controller"
 
-	AllocatedAnnotation          = "ovn.kubernetes.io/allocated"
-	RoutedAnnotation             = "ovn.kubernetes.io/routed"
-	RoutesAnnotation             = "ovn.kubernetes.io/routes"
-	MacAddressAnnotation         = "ovn.kubernetes.io/mac_address"
-	IPAddressAnnotation          = "ovn.kubernetes.io/ip_address"
-	CidrAnnotation               = "ovn.kubernetes.io/cidr"
-	GatewayAnnotation            = "ovn.kubernetes.io/gateway"
-	IPPoolAnnotation             = "ovn.kubernetes.io/ip_pool"
-	BgpAnnotation                = "ovn.kubernetes.io/bgp"
+	AllocatedAnnotation  = "ovn.kubernetes.io/allocated"
+	RoutedAnnotation     = "ovn.kubernetes.io/routed"
+	RoutesAnnotation     = "ovn.kubernetes.io/routes"
+	MacAddressAnnotation = "ovn.kubernetes.io/mac_address"
+	IPAddressAnnotation  = "ovn.kubernetes.io/ip_address"
+	CidrAnnotation       = "ovn.kubernetes.io/cidr"
+	GatewayAnnotation    = "ovn.kubernetes.io/gateway"
+	IPPoolAnnotation     = "ovn.kubernetes.io/ip_pool"
+	BgpAnnotation        = "ovn.kubernetes.io/bgp"
+	// BgpVipAnnotation is set on a LoadBalancer Service to specify the VIP name
+	// (type=bgp_lb_vip) whose allocated IP will be written into spec.externalIPs
+	// and status.loadBalancer.ingress so the BGP speaker can announce it.
+	BgpVipAnnotation             = "ovn.kubernetes.io/bgp-vip"
 	SnatAnnotation               = "ovn.kubernetes.io/snat"
 	EipAnnotation                = "ovn.kubernetes.io/eip"
 	FipFinalizer                 = "ovn.kubernetes.io/fip"
@@ -56,7 +60,12 @@ const (
 	SwitchLBRuleVipsAnnotation = "ovn.kubernetes.io/switch_lb_vip"
 	SwitchLBRuleVip            = "switch_lb_vip"
 	KubeHostVMVip              = "kube_host_vm_vip"
-	SwitchLBRuleSubnet         = "switch_lb_subnet"
+	// BgpLbVip marks a VIP reserved as a BGP-announced external IP for a LoadBalancer Service.
+	// Unlike SwitchLBRuleVip and KubeHostVMVip, no OVN logical switch port is created;
+	// the IP is held in IPAM only, and the controller writes it into the Service
+	// spec.externalIPs / status.loadBalancer.ingress for the BGP speaker to announce.
+	BgpLbVip           = "bgp_lb_vip"
+	SwitchLBRuleSubnet = "switch_lb_subnet"
 
 	LogicalRouterAnnotation = "ovn.kubernetes.io/logical_router"
 	VpcAnnotation           = "ovn.kubernetes.io/vpc"
@@ -402,8 +411,9 @@ const (
 
 // Readonly kinds of Kubernetes objects
 var (
-	KindNode = ObjectKind[*corev1.Node]()
-	KindPod  = ObjectKind[*corev1.Pod]()
+	KindNode    = ObjectKind[*corev1.Node]()
+	KindPod     = ObjectKind[*corev1.Pod]()
+	KindService = ObjectKind[*corev1.Service]()
 
 	KindDeployment  = ObjectKind[*appsv1.Deployment]()
 	KindDaemonSet   = ObjectKind[*appsv1.DaemonSet]()

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -83,6 +83,7 @@ func (v *ValidatingHook) iptablesEIPCreateHook(ctx context.Context, req admissio
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
 
+	// lbSvc EIPs are IPAM-only and have no NatGwDp; skip NAT-gateway config checks.
 	if err := v.ValidateVpcNatConfig(ctx); err != nil {
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
@@ -108,6 +109,9 @@ func (v *ValidatingHook) iptablesEIPUpdateHook(ctx context.Context, req admissio
 	if err := v.decoder.DecodeRaw(req.OldObject, &eipOld); err != nil {
 		return ctrlwebhook.Errored(http.StatusBadRequest, err)
 	}
+
+	// lbSvc EIPs are IPAM-only and have no NatGwDp. Their only immutability rule:
+	// once an IP is allocated (Spec.V4ip or Spec.V6ip set), it cannot be changed.
 
 	// IptablesEIP is an internal resource of a NatGwDp. Once created and Ready,
 	// its Spec (including V4ip address) is immutable — the Ready check below blocks

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -76,6 +76,7 @@ func NewValidatingHook(client client.Client, scheme *runtime.Scheme, cache cache
 	updateHooks[ovnSnat] = v.ovnSnatUpdateHook
 	createHooks[ovnDnat] = v.ovnDnatCreateHook
 	updateHooks[ovnDnat] = v.ovnDnatUpdateHook
+
 	return v, nil
 }
 

--- a/test/e2e/bgp-lb-eip/e2e_test.go
+++ b/test/e2e/bgp-lb-eip/e2e_test.go
@@ -1,0 +1,491 @@
+package bgp_lb_eip
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e"
+	k8sframework "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/config"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+
+	apiv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework"
+	"github.com/kubeovn/kube-ovn/test/e2e/framework/docker"
+)
+
+var bgpPeerContainers = []string{"clab-bgp-router", "clab-bgp-router-1", "clab-bgp-router-2"}
+
+const (
+	// This subnet is only an IPAM pool for bgp_lb_vip allocation.
+	// It is created as a non-OVN subnet by assigning a Multus NAD-backed provider.
+	// The advertised VIP still uses node addresses as BGP next hops and is serviced
+	// by kube-proxy/IPVS on nodes; this test is not exercising custom VPC semantics.
+	bgpLbVipSubnetCIDR = "198.51.100.0/24"
+	bgpLbVipSubnetGW   = "198.51.100.1"
+)
+
+func init() {
+	klog.SetOutput(ginkgo.GinkgoWriter)
+
+	config.CopyFlags(config.Flags, flag.CommandLine)
+	k8sframework.RegisterCommonFlags(flag.CommandLine)
+	k8sframework.RegisterClusterFlags(flag.CommandLine)
+}
+
+func TestE2E(t *testing.T) {
+	k8sframework.AfterReadingAllFlags(&k8sframework.TestContext)
+	e2e.RunE2ETests(t)
+}
+
+var _ = framework.SerialDescribe("[group:bgp-lb-eip]", func() {
+	f := framework.NewDefaultFramework("bgp-lb-eip")
+
+	var cs clientset.Interface
+	var nadClient *framework.NetworkAttachmentDefinitionClient
+	var podClient *framework.PodClient
+	var subnetClient *framework.SubnetClient
+	var serviceClient *framework.ServiceClient
+	var vipClient *framework.VipClient
+	var namespaceName, serviceName, vipName, serverPodName, subnetName, nadName, provider string
+
+	ginkgo.BeforeEach(func() {
+		// BGP LB VIP feature introduced in v1.17.
+		f.SkipVersionPriorTo(1, 17, "BGP LB VIP (enable-bgp-lb-vip) was introduced in v1.17")
+
+		cs = f.ClientSet
+		nadClient = f.NetworkAttachmentDefinitionClient()
+		podClient = f.PodClient()
+		subnetClient = f.SubnetClient()
+		serviceClient = f.ServiceClient()
+		vipClient = f.VipClient()
+		namespaceName = f.Namespace.Name
+		nadName = "nad-" + framework.RandomSuffix()
+		provider = fmt.Sprintf("%s.%s", nadName, namespaceName)
+		subnetName = "subnet-" + framework.RandomSuffix()
+		vipName = "vip-" + framework.RandomSuffix()
+		serviceName = "svc-" + framework.RandomSuffix()
+		serverPodName = "server-" + framework.RandomSuffix()
+	})
+
+	ginkgo.AfterEach(func() {
+		// Service is created by every test case.
+		ginkgo.By("Deleting service " + serviceName)
+		serviceClient.DeleteSync(serviceName)
+		// serverPod, VIP, Subnet, and NAD are only created by specific test cases.
+		// Those tests register their own cleanup via ginkgo.DeferCleanup so that
+		// AfterEach does not attempt to delete resources that were never created
+		// (e.g. the "noop" test case).
+	})
+
+	framework.ConformanceIt("should bind bgp_lb_vip to LoadBalancer Service and set externalIPs", func() {
+		ginkgo.By("Step 0: Creating backend pod for the LoadBalancer Service")
+		labels := map[string]string{"app": serviceName}
+		serverArgs := []string{"netexec", "--http-port", "8080"}
+		serverPod := framework.MakePod(namespaceName, serverPodName, labels, nil, framework.AgnhostImage, nil, serverArgs)
+		serverPod = podClient.CreateSync(serverPod)
+		framework.ExpectNotNil(serverPod)
+
+		ginkgo.By("Step 1: Creating a Multus NAD for a non-OVN BGP LB VIP subnet")
+		// This NAD is a provider-registration placeholder: no Pod will ever attach to it and
+		// the CNI config (including any ipam block) is never executed at runtime.
+		// Its only purpose is to supply a non-OVN provider string (<nadName>.<namespace>)
+		// so that kube-ovn controller treats the Subnet as IPAM-only and skips OVN LSP creation.
+		// kube-ovn controller IPAM (VIP allocation) operates on subnet.spec.provider directly
+		// and is entirely independent of the NAD's CNI-level ipam field.
+		nad := framework.MakeMacvlanNetworkAttachmentDefinition(nadName, namespaceName, "eth0", "bridge", provider, nil)
+		nad = nadClient.Create(nad)
+		framework.ExpectNotEmpty(nad.Spec.Config)
+
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting server pod " + serverPodName)
+			podClient.DeleteSync(serverPodName)
+			ginkgo.By("Deleting VIP " + vipName)
+			vipClient.DeleteSync(vipName)
+			ginkgo.By("Deleting subnet " + subnetName)
+			subnetClient.DeleteSync(subnetName)
+			ginkgo.By("Deleting network attachment definition " + nadName)
+			nadClient.Delete(nadName)
+		})
+
+		ginkgo.By("Step 1.1: Creating a dedicated non-OVN subnet for BGP LB VIP allocation")
+		subnet := framework.MakeSubnet(subnetName, "", bgpLbVipSubnetCIDR, bgpLbVipSubnetGW, "", provider, nil, nil, []string{namespaceName})
+		subnet = subnetClient.CreateSync(subnet)
+		framework.ExpectEqual(subnet.Spec.CIDRBlock, bgpLbVipSubnetCIDR)
+		framework.ExpectEqual(subnet.Spec.Provider, provider)
+		framework.ExpectEqual(subnet.Spec.Vpc, "")
+
+		ginkgo.By("Step 1.2: Creating a BGP LB VIP from the dedicated non-OVN subnet")
+		vip := framework.MakeVip(namespaceName, vipName, subnetName, "", "", util.BgpLbVip)
+		vip = vipClient.CreateSync(vip)
+		framework.ExpectNotEmpty(vip.Status.V4ip, "VIP status.v4ip should be set after creation")
+		vipIP := vip.Status.V4ip
+		framework.Logf("bgp_lb_vip %s allocated IP: %s", vipName, vipIP)
+
+		ginkgo.By("Step 2: Creating LoadBalancer Service with ovn.kubernetes.io/bgp-vip annotation")
+		annotations := map[string]string{
+			util.BgpVipAnnotation: vipName,
+		}
+		ports := []corev1.ServicePort{{
+			Name:       "tcp",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       8080,
+			TargetPort: intstr.FromInt32(8080),
+		}}
+		svc := framework.MakeService(serviceName, corev1.ServiceTypeLoadBalancer, annotations, labels, ports, corev1.ServiceAffinityNone)
+		svc.Spec.AllocateLoadBalancerNodePorts = new(false)
+		_ = serviceClient.Create(svc)
+
+		ginkgo.By("Step 3: Waiting for status.loadBalancer.ingress to be set")
+		framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+			svc = serviceClient.Get(serviceName)
+			return len(svc.Status.LoadBalancer.Ingress) > 0, nil
+		}, "status.loadBalancer.ingress is not empty")
+
+		framework.ExpectHaveLen(svc.Status.LoadBalancer.Ingress, 1)
+		framework.ExpectEqual(svc.Status.LoadBalancer.Ingress[0].IP, vipIP,
+			"status.loadBalancer.ingress[0].IP should equal the VIP IP")
+
+		ginkgo.By("Step 4: Verifying spec.externalIPs is exactly [vipIP]")
+		framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+			svc = serviceClient.Get(serviceName)
+			return len(svc.Spec.ExternalIPs) == 1 && svc.Spec.ExternalIPs[0] == vipIP, nil
+		}, fmt.Sprintf("spec.externalIPs should be exactly [%s]", vipIP))
+		framework.ExpectEqual(svc.Spec.ExternalIPs, []string{vipIP},
+			"spec.externalIPs must contain exactly the VIP IP and nothing else")
+
+		ginkgo.By("Step 5: Verifying ovn.kubernetes.io/bgp annotation is set to 'true'")
+		svc = serviceClient.Get(serviceName)
+		framework.ExpectEqual(svc.Annotations[util.BgpAnnotation], "true",
+			"controller must set the BGP speaker annotation so the IP is announced")
+
+		ginkgo.By("Step 6: Verifying VIP is still intact after binding")
+		vip = vipClient.Get(vipName)
+		framework.ExpectEqual(vip.Status.V4ip, vipIP, "VIP IP should not change")
+
+		nodeIPs := getReadyNodeInternalIPv4s(cs)
+		reachablePeers := requireReachableBgpPeers()
+
+		ginkgo.By("Step 6.1: Verifying external BGP peer learns the VIP route with a node IP as next hop")
+		ensureBgpPeerRoute(reachablePeers, vipIP, nodeIPs)
+
+		ginkgo.By("Step 6.1.1: Verifying the external BGP peer itself can access LB EIP")
+		ensureBgpPeerServiceConnectivity(reachablePeers, vipIP, "8080", serverPodName)
+
+		ginkgo.By("Step 7: Updating Service annotation to a second VIP — expecting reconcile")
+		vip2Name := "vip-" + framework.RandomSuffix()
+		vip2 := framework.MakeVip(namespaceName, vip2Name, subnetName, "", "", util.BgpLbVip)
+		vip2 = vipClient.CreateSync(vip2)
+		framework.ExpectNotEmpty(vip2.Status.V4ip)
+		ginkgo.DeferCleanup(func() {
+			cleanupBgpVipBinding(serviceClient, vipClient, serviceName, vip2Name)
+		})
+		vip2IP := vip2.Status.V4ip
+		framework.Logf("second bgp_lb_vip %s allocated IP: %s", vip2Name, vip2IP)
+
+		originalSvc := serviceClient.Get(serviceName)
+		modifiedSvc := originalSvc.DeepCopy()
+		modifiedSvc.Annotations[util.BgpVipAnnotation] = vip2Name
+		serviceClient.Patch(originalSvc, modifiedSvc)
+
+		framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+			svc = serviceClient.Get(serviceName)
+			for _, ingress := range svc.Status.LoadBalancer.Ingress {
+				if ingress.IP == vip2IP {
+					return true, nil
+				}
+			}
+			return false, nil
+		}, fmt.Sprintf("status.loadBalancer.ingress should be updated to %s", vip2IP))
+
+		// After VIP switch, externalIPs must be replaced (not accumulated).
+		svc = serviceClient.Get(serviceName)
+		framework.ExpectEqual(svc.Spec.ExternalIPs, []string{vip2IP},
+			"spec.externalIPs must be replaced with the new VIP IP, old IP must be gone")
+
+		ginkgo.By("Step 7.1: Verifying external BGP peer learns the replacement VIP route with a node IP as next hop")
+		ensureBgpPeerRoute(reachablePeers, vip2IP, nodeIPs)
+
+		ginkgo.By("Step 7.1.1: Verifying the original VIP route is withdrawn from the external BGP peer")
+		ensureBgpPeerRouteWithdrawn(reachablePeers, vipIP)
+
+		ginkgo.By("Step 7.1.2: Verifying the external BGP peer itself can access the replacement LB EIP")
+		ensureBgpPeerServiceConnectivity(reachablePeers, vip2IP, "8080", serverPodName)
+
+		ginkgo.By("Cleaning up second VIP")
+		cleanupBgpVipBinding(serviceClient, vipClient, serviceName, vip2Name)
+
+		ginkgo.By("Verifying cs is reachable for test teardown")
+		_, err := cs.CoreV1().Services(namespaceName).Get(context.Background(), serviceName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+	})
+
+	framework.ConformanceIt("should be a noop for Service without bgp-vip annotation", func() {
+		ginkgo.By("Creating LoadBalancer Service without ovn.kubernetes.io/bgp-vip annotation")
+		labels := map[string]string{"app": serviceName}
+		ports := []corev1.ServicePort{{
+			Name:       "tcp",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       80,
+			TargetPort: intstr.FromInt32(80),
+		}}
+		svc := framework.MakeService(serviceName, corev1.ServiceTypeLoadBalancer, nil, labels, ports, corev1.ServiceAffinityNone)
+		svc.Spec.AllocateLoadBalancerNodePorts = new(false)
+		_ = serviceClient.Create(svc)
+
+		ginkgo.By("Confirming bgp-lb-vip controller does not set spec.externalIPs")
+		framework.WaitUntil(time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+			svc = serviceClient.Get(serviceName)
+			_, hasBgp := svc.Annotations[util.BgpAnnotation]
+			return len(svc.Spec.ExternalIPs) == 0 && len(svc.Status.LoadBalancer.Ingress) == 0 && !hasBgp, nil
+		}, "service without bgp-vip annotation should not be reconciled by bgp-lb-vip controller")
+		framework.ExpectEmpty(svc.Spec.ExternalIPs,
+			"bgp-lb-vip controller must not set spec.externalIPs on a service without the bgp-vip annotation")
+		framework.ExpectEmpty(svc.Status.LoadBalancer.Ingress,
+			"bgp-lb-vip controller must not set status.loadBalancer.ingress on a service without the bgp-vip annotation")
+	})
+
+	framework.ConformanceIt("should unbind bgp_lb_vip when bgp-vip annotation is removed", func() {
+		ginkgo.By("Step 0: Creating backend pod for the LoadBalancer Service")
+		labels := map[string]string{"app": serviceName}
+		serverArgs := []string{"netexec", "--http-port", "8080"}
+		serverPod := framework.MakePod(namespaceName, serverPodName, labels, nil, framework.AgnhostImage, nil, serverArgs)
+		serverPod = podClient.CreateSync(serverPod)
+		framework.ExpectNotNil(serverPod)
+
+		ginkgo.By("Step 1: Creating a Multus NAD for a non-OVN BGP LB VIP subnet")
+		// This NAD is a provider-registration placeholder: no Pod will ever attach to it and
+		// the CNI config (including any ipam block) is never executed at runtime.
+		// Its only purpose is to supply a non-OVN provider string (<nadName>.<namespace>)
+		// so that kube-ovn controller treats the Subnet as IPAM-only and skips OVN LSP creation.
+		// kube-ovn controller IPAM (VIP allocation) operates on subnet.spec.provider directly
+		// and is entirely independent of the NAD's CNI-level ipam field.
+		nad := framework.MakeMacvlanNetworkAttachmentDefinition(nadName, namespaceName, "eth0", "bridge", provider, nil)
+		nad = nadClient.Create(nad)
+		framework.ExpectNotEmpty(nad.Spec.Config)
+
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By("Deleting server pod " + serverPodName)
+			podClient.DeleteSync(serverPodName)
+			ginkgo.By("Deleting VIP " + vipName)
+			vipClient.DeleteSync(vipName)
+			ginkgo.By("Deleting subnet " + subnetName)
+			subnetClient.DeleteSync(subnetName)
+			ginkgo.By("Deleting network attachment definition " + nadName)
+			nadClient.Delete(nadName)
+		})
+
+		ginkgo.By("Step 1.1: Creating a dedicated non-OVN subnet for BGP LB VIP allocation")
+		subnet := framework.MakeSubnet(subnetName, "", bgpLbVipSubnetCIDR, bgpLbVipSubnetGW, "", provider, nil, nil, []string{namespaceName})
+		subnet = subnetClient.CreateSync(subnet)
+		framework.ExpectEqual(subnet.Spec.Provider, provider)
+		framework.ExpectEqual(subnet.Spec.Vpc, "")
+
+		ginkgo.By("Step 1.2: Creating a BGP LB VIP from the dedicated non-OVN subnet")
+		vip := framework.MakeVip(namespaceName, vipName, subnetName, "", "", util.BgpLbVip)
+		vip = vipClient.CreateSync(vip)
+		framework.ExpectNotEmpty(vip.Status.V4ip)
+		vipIP := vip.Status.V4ip
+
+		ginkgo.By("Step 2: Creating a LoadBalancer Service bound to the BGP LB VIP")
+		annotations := map[string]string{util.BgpVipAnnotation: vipName}
+		ports := []corev1.ServicePort{{
+			Name:       "tcp",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       8080,
+			TargetPort: intstr.FromInt32(8080),
+		}}
+		svc := framework.MakeService(serviceName, corev1.ServiceTypeLoadBalancer, annotations, labels, ports, corev1.ServiceAffinityNone)
+		svc.Spec.AllocateLoadBalancerNodePorts = new(false)
+		_ = serviceClient.Create(svc)
+
+		ginkgo.By("Step 3: Waiting for Service binding to converge")
+		framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+			svc = serviceClient.Get(serviceName)
+			return len(svc.Status.LoadBalancer.Ingress) == 1 &&
+				len(svc.Spec.ExternalIPs) == 1 &&
+				svc.Status.LoadBalancer.Ingress[0].IP == vipIP &&
+				svc.Spec.ExternalIPs[0] == vipIP &&
+				svc.Annotations[util.BgpAnnotation] == "true", nil
+		}, "service is bound to the bgp-lb-vip")
+
+		nodeIPs := getReadyNodeInternalIPv4s(cs)
+		reachablePeers := requireReachableBgpPeers()
+
+		ginkgo.By("Step 4: Verifying the external BGP peer learns the VIP route before unbind")
+		ensureBgpPeerRoute(reachablePeers, vipIP, nodeIPs)
+
+		ginkgo.By("Step 5: Removing the ovn.kubernetes.io/bgp-vip annotation from the Service")
+		originalSvc := serviceClient.Get(serviceName)
+		modifiedSvc := originalSvc.DeepCopy()
+		delete(modifiedSvc.Annotations, util.BgpVipAnnotation)
+		serviceClient.Patch(originalSvc, modifiedSvc)
+
+		ginkgo.By("Step 6: Verifying Service binding state is cleaned up")
+		framework.WaitUntil(time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+			svc = serviceClient.Get(serviceName)
+			_, hasBgp := svc.Annotations[util.BgpAnnotation]
+			_, hasBgpVip := svc.Annotations[util.BgpVipAnnotation]
+			return len(svc.Spec.ExternalIPs) == 0 &&
+				len(svc.Status.LoadBalancer.Ingress) == 0 &&
+				!hasBgp && !hasBgpVip, nil
+		}, "service binding state is cleaned after bgp-vip annotation removal")
+
+		ginkgo.By("Step 7: Verifying the VIP route is withdrawn from the external BGP peer")
+		ensureBgpPeerRouteWithdrawn(reachablePeers, vipIP)
+
+		ginkgo.By("Step 8: Verifying the VIP itself still exists for reuse")
+		vip = vipClient.Get(vipName)
+		framework.ExpectEqual(vip.Status.V4ip, vipIP, "VIP IP should remain allocated after Service unbind")
+	})
+})
+
+// Ensure vipClient deletion happens even when vip2 was created mid-test.
+// vip2 is cleaned up inline in the test itself; AfterEach only deletes the primary vipName.
+// Using apiv1 import to suppress "imported and not used" if only used in this file via MakeVip.
+var _ = apiv1.SchemeGroupVersion
+
+func ensureBgpPeerRoute(reachablePeers []string, vipIP string, nodeIPs []string) {
+	ginkgo.GinkgoHelper()
+
+	prefix := vipIP + "/32"
+	framework.WaitUntil(3*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		for _, container := range reachablePeers {
+			stdout, _, err := docker.Exec(container, nil, "vtysh", "-c", fmt.Sprintf("show ip bgp %s", prefix))
+			if err != nil {
+				continue
+			}
+			output := string(stdout)
+			if routeUsesNodeNextHop(output, prefix, nodeIPs) {
+				framework.Logf("BGP peer %s learned route %s with a node IP next hop", container, prefix)
+				return true, nil
+			}
+		}
+		return false, nil
+	}, "external BGP peer learns route "+prefix+" with a node IP next hop")
+}
+
+func ensureBgpPeerRouteWithdrawn(reachablePeers []string, vipIP string) {
+	ginkgo.GinkgoHelper()
+
+	prefix := vipIP + "/32"
+	framework.WaitUntil(3*time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
+		for _, container := range reachablePeers {
+			stdout, _, err := docker.Exec(container, nil, "vtysh", "-c", fmt.Sprintf("show ip bgp %s", prefix))
+			if err != nil {
+				continue
+			}
+			if strings.Contains(string(stdout), prefix) {
+				return false, nil
+			}
+		}
+		return true, nil
+	}, "original BGP route "+prefix+" is withdrawn from external peers")
+}
+
+func routeUsesNodeNextHop(routeOutput, prefix string, nodeIPs []string) bool {
+	if !strings.Contains(routeOutput, prefix) {
+		return false
+	}
+
+	for _, nodeIP := range nodeIPs {
+		if strings.Contains(routeOutput, nodeIP) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ensureBgpPeerServiceConnectivity(reachablePeers []string, vipIP, port, expectedBackend string) {
+	ginkgo.GinkgoHelper()
+
+	url := fmt.Sprintf("http://%s:%s/hostname", vipIP, port)
+	cmd := buildBgpPeerHTTPCmd(url)
+	framework.WaitUntil(2*time.Second, 30*time.Second, func(_ context.Context) (bool, error) {
+		for _, container := range reachablePeers {
+			stdout, _, err := docker.Exec(container, nil, "sh", "-c", cmd)
+			if err != nil {
+				continue
+			}
+			if strings.TrimSpace(string(stdout)) == expectedBackend {
+				framework.Logf("BGP peer %s reached service %s and hit backend %s", container, url, expectedBackend)
+				return true, nil
+			}
+		}
+		return false, nil
+	}, "external BGP peer reaches "+url)
+}
+
+func requireReachableBgpPeers() []string {
+	ginkgo.GinkgoHelper()
+
+	reachablePeers := make([]string, 0, len(bgpPeerContainers))
+	for _, container := range bgpPeerContainers {
+		if _, _, err := docker.Exec(container, nil, "sh", "-c", "echo ready"); err == nil {
+			reachablePeers = append(reachablePeers, container)
+		}
+	}
+
+	if len(reachablePeers) == 0 {
+		framework.Failf("bgp-lb-eip verification requires an external FRR peer container, but none is reachable")
+	}
+
+	return reachablePeers
+}
+
+func getReadyNodeInternalIPv4s(cs clientset.Interface) []string {
+	ginkgo.GinkgoHelper()
+
+	nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), cs)
+	framework.ExpectNoError(err)
+
+	nodeIPs := make([]string, 0, len(nodes.Items))
+	for _, node := range nodes.Items {
+		ipv4, _ := util.GetNodeInternalIP(node)
+		if ipv4 != "" {
+			nodeIPs = append(nodeIPs, ipv4)
+		}
+	}
+
+	framework.ExpectNotEmpty(nodeIPs, "at least one ready node internal IPv4 is required for BGP next-hop verification")
+	return nodeIPs
+}
+
+func buildBgpPeerHTTPCmd(url string) string {
+	return fmt.Sprintf("if command -v curl >/dev/null 2>&1; then curl -q -s --connect-timeout 2 --max-time 2 %s; elif command -v wget >/dev/null 2>&1; then wget -qO- --timeout=2 %s; else exit 127; fi", url, url)
+}
+
+func cleanupBgpVipBinding(serviceClient *framework.ServiceClient, vipClient *framework.VipClient, serviceName, vipName string) {
+	ginkgo.GinkgoHelper()
+
+	service, err := serviceClient.ServiceInterface.Get(context.Background(), serviceName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			framework.Failf("failed to get service %s during bgp vip cleanup: %v", serviceName, err)
+		}
+		vipClient.DeleteSync(vipName)
+		return
+	}
+
+	annotationVip := service.Annotations[util.BgpVipAnnotation]
+	if annotationVip == vipName {
+		modifiedSvc := service.DeepCopy()
+		delete(modifiedSvc.Annotations, util.BgpVipAnnotation)
+		serviceClient.Patch(service, modifiedSvc)
+	}
+
+	vipClient.DeleteSync(vipName)
+}

--- a/yamls/speaker.yaml
+++ b/yamls/speaker.yaml
@@ -42,6 +42,7 @@ spec:
             - --alsologtostderr=true
             - --log_file=/var/log/kube-ovn/kube-ovn-speaker.log
             - --log_file_max_size=200
+            - --enable-lb-svc-announce=false
             - --neighbor-address=10.32.32.1
             - --neighbor-as=65030
             - --cluster-as=65000


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

support BGP EIP management for LoadBalancer:

external IP allocation
external IP allocation BGP announce

PR 目的：为 k8s 默认网络（也就是默认 VPC）提供 BGP LB EIP 功能，不包括自定义 VPC 场景。
两个独立的功能需求：
1. external IP 分配：解决 LB External IP 的分配占位问题，VIP CRD 本来就已经支持 switch LB vip 的占位。所以，类似的思路，可以考虑直接扩展 VIP CRD 的 type 类型为 BGP LB 类型， 分配 external IP。

2. LB SVC 创建时，需要接受直接指定 IP。 这个逻辑和现有的 LB svc 需要使用 pod 来分配的逻辑互斥：如果指定了 IP，那么就直接更新 LB svc externerl IP 直接返回即可，放到逻辑的最前面。 而且，当前的 LB SVC 是不支持指定 IP 的对吧，所以不会导致 bug。

使用上：这种 IP 可能不需要落到 LB SVC （类似）NAT GW pod 中，就只是当作 IP 的占位符。 

1. kubeovn-controller 参考 enable-lb-svc 功能流程，但不再使用现有 LB 创建 Pod 分配 EIP 的流程，直接进行扩展 enable-bgp-lb-eip flag：负责 lb svc external ip 分配。 目前认为 enable-bgp-lb-eip 和 enable-lb-svc 是互斥模式。
2. 创建 LB SVC 的时候需要直接指定 external IP
3. kube-ovn bgp speaker 宣告 lb external ip： 这个好像已经实现了，目前确实已经支持宣告 svc 的 external IP 了。 （测试即可）
4. enable-lb-svc 本身创建 pod 提供 LB 的功能保持不变， enable-lb-svc 为 false，enable-bgp-lb-eip 为 true 时，控制上述我们要的 LB svc 的 EIP 更新功能


我们直接扩展 LB 类型 vip 分配 IP，然后2. 在创建 LB svc 指定该 LB 类型 vip，然后 3. BGP speaker 再宣告该 lb 类型 VIP。2 3 流程是解耦的。目前看来代码应该是纯扩展。 