### PR TITLE
feat(bgpspeaker): gate lb vip announcements by node label

### DIFF
--- a/charts/kube-ovn-v2/templates/speaker/speaker.yaml
+++ b/charts/kube-ovn-v2/templates/speaker/speaker.yaml
@@ -82,6 +82,10 @@ spec:
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -277,6 +277,12 @@ func (config *Configuration) validateRequiredFlags() error {
 		missingFlags = append(missingFlags, "--neighbor-as must be specified")
 	}
 
+	// EnableLbSvcAnnounce requires NodeName so the speaker can read the local
+	// node label gate for Service VIP announcements.
+	if config.EnableLbSvcAnnounce && config.NodeName == "" {
+		missingFlags = append(missingFlags, "--enable-lb-svc-announce requires --node-name to be specified")
+	}
+
 	// NodeRouteEIPMode requires NodeName to identify local NAT gateway pods
 	if config.NodeRouteEIPMode && config.NodeName == "" {
 		missingFlags = append(missingFlags, "--node-route-eip-mode requires --node-name to be specified")

--- a/pkg/speaker/config_test.go
+++ b/pkg/speaker/config_test.go
@@ -86,6 +86,17 @@ func TestValidateRequiredFlags(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "enable lb svc announce requires node-name",
+			config: &Configuration{
+				NeighborAddresses:   []net.IP{net.ParseIP("192.168.1.1")},
+				ClusterAs:           65000,
+				NeighborAs:          65001,
+				EnableLbSvcAnnounce: true,
+			},
+			expectError: true,
+			errContains: []string{"enable-lb-svc-announce", "node-name"},
+		},
+		{
 			name: "nat-gw mode does not require node-name",
 			config: &Configuration{
 				NeighborAddresses: []net.IP{net.ParseIP("192.168.1.1")},

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -27,6 +27,9 @@ const controllerAgentName = "ovn-speaker"
 type Controller struct {
 	config *Configuration
 
+	nodesLister listerv1.NodeLister
+	nodesSynced cache.InformerSynced
+
 	podsLister listerv1.PodLister
 	podsSynced cache.InformerSynced
 
@@ -96,6 +99,7 @@ func NewController(config *Configuration) *Controller {
 		}))
 
 	podInformer := podInformerFactory.Core().V1().Pods()
+	nodeInformer := informerFactory.Core().V1().Nodes()
 	subnetInformer := kubeovnInformerFactory.Kubeovn().V1().Subnets()
 	serviceInformer := informerFactory.Core().V1().Services()
 	eipInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesEIPs()
@@ -104,6 +108,8 @@ func NewController(config *Configuration) *Controller {
 	controller := &Controller{
 		config: config,
 
+		nodesLister:      nodeInformer.Lister(),
+		nodesSynced:      nodeInformer.Informer().HasSynced,
 		podsLister:       podInformer.Lister(),
 		podsSynced:       podInformer.Informer().HasSynced,
 		subnetsLister:    subnetInformer.Lister(),
@@ -146,7 +152,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		c.gwPodsInformerFactory.Start(stopCh)
 	}
 
-	cacheSyncs := []cache.InformerSynced{c.podsSynced, c.subnetSynced, c.servicesSynced, c.eipSynced}
+	cacheSyncs := []cache.InformerSynced{c.nodesSynced, c.podsSynced, c.subnetSynced, c.servicesSynced, c.eipSynced}
 	if c.gwPodsSynced != nil {
 		cacheSyncs = append(cacheSyncs, c.gwPodsSynced)
 	}
@@ -186,14 +192,18 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 // The two modes above are mutually exclusive because they both claim ownership of IptablesEIP
 // BGP routes and would conflict if run together.
 //
-// Service VIP announcement (independent — composable with either EIP mode):
+// Service VIP announcement (independent from IptablesEIP, but not enabled in every mode):
 //
 //	--enable-lb-svc-announce:
 //	    Announces LoadBalancer Service ingress IPs (VIPs live on kube-ipvs0 on
 //	    every node, managed by kube-proxy/iptables). This plane is orthogonal to
 //	    IptablesEIP — different resources, different network plane, no conflict.
-//	    When node-route-eip-mode is active, syncNodeRouteEIPs() merges Service VIP
-//	    prefixes (expectedBgpLbServiceEip) into the expected set before reconciling.
+//	    Supported execution paths:
+//	    1. Default mode: syncSubnetRoutes() includes Service VIP prefixes.
+//	    2. node-route-eip-mode: syncNodeRouteEIPs() merges Service VIP prefixes
+//	       (expectedBgpLbServiceEip) into the expected set before reconciling.
+//	    nat-gw-mode does not participate in Service VIP announcement; it only
+//	    announces NAT gateway EIPs from inside the gateway pod.
 func (c *Controller) Reconcile() {
 	switch {
 	case c.config.NatGwMode:

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -54,6 +54,7 @@ type Controller struct {
 	eipQueue workqueue.TypedRateLimitingInterface[string]
 
 	informerFactory        kubeinformers.SharedInformerFactory
+	nodeInformerFactory    kubeinformers.SharedInformerFactory
 	podInformerFactory     kubeinformers.SharedInformerFactory
 	gwPodsInformerFactory  kubeinformers.SharedInformerFactory
 	kubeovnInformerFactory kubeovninformer.SharedInformerFactory
@@ -73,6 +74,15 @@ func NewController(config *Configuration) *Controller {
 		kubeinformers.WithTweakListOptions(func(listOption *metav1.ListOptions) {
 			listOption.AllowWatchBookmarks = true
 		}))
+	var nodeInformerFactory kubeinformers.SharedInformerFactory
+	if config.EnableLbSvcAnnounce {
+		nodeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(config.KubeClient, 0,
+			kubeinformers.WithTransform(util.TrimManagedFields),
+			kubeinformers.WithTweakListOptions(func(listOption *metav1.ListOptions) {
+				listOption.FieldSelector = "metadata.name=" + config.NodeName
+				listOption.AllowWatchBookmarks = true
+			}))
+	}
 	podInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(config.KubeClient, 0,
 		kubeinformers.WithTransform(util.TrimManagedFields),
 		kubeinformers.WithTweakListOptions(func(listOption *metav1.ListOptions) {
@@ -99,17 +109,24 @@ func NewController(config *Configuration) *Controller {
 		}))
 
 	podInformer := podInformerFactory.Core().V1().Pods()
-	nodeInformer := informerFactory.Core().V1().Nodes()
 	subnetInformer := kubeovnInformerFactory.Kubeovn().V1().Subnets()
 	serviceInformer := informerFactory.Core().V1().Services()
 	eipInformer := kubeovnInformerFactory.Kubeovn().V1().IptablesEIPs()
 	natgatewayInformer := kubeovnInformerFactory.Kubeovn().V1().VpcNatGateways()
 
+	var nodesLister listerv1.NodeLister
+	nodesSynced := cache.InformerSynced(func() bool { return true })
+	if nodeInformerFactory != nil {
+		nodeInformer := nodeInformerFactory.Core().V1().Nodes()
+		nodesLister = nodeInformer.Lister()
+		nodesSynced = nodeInformer.Informer().HasSynced
+	}
+
 	controller := &Controller{
 		config: config,
 
-		nodesLister:      nodeInformer.Lister(),
-		nodesSynced:      nodeInformer.Informer().HasSynced,
+		nodesLister:      nodesLister,
+		nodesSynced:      nodesSynced,
 		podsLister:       podInformer.Lister(),
 		podsSynced:       podInformer.Informer().HasSynced,
 		subnetsLister:    subnetInformer.Lister(),
@@ -122,6 +139,7 @@ func NewController(config *Configuration) *Controller {
 		natgatewaySynced: natgatewayInformer.Informer().HasSynced,
 
 		informerFactory:        informerFactory,
+		nodeInformerFactory:    nodeInformerFactory,
 		podInformerFactory:     podInformerFactory,
 		gwPodsInformerFactory:  gwPodsInformerFactory,
 		kubeovnInformerFactory: kubeovnInformerFactory,
@@ -144,6 +162,9 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	defer c.shutdownNodeRouteEIPWorkers()
 
 	c.informerFactory.Start(stopCh)
+	if c.nodeInformerFactory != nil {
+		c.nodeInformerFactory.Start(stopCh)
+	}
 	c.podInformerFactory.Start(stopCh)
 	c.kubeovnInformerFactory.Start(stopCh)
 
@@ -152,7 +173,8 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		c.gwPodsInformerFactory.Start(stopCh)
 	}
 
-	cacheSyncs := []cache.InformerSynced{c.nodesSynced, c.podsSynced, c.subnetSynced, c.servicesSynced, c.eipSynced}
+	cacheSyncs := []cache.InformerSynced{c.podsSynced, c.subnetSynced, c.servicesSynced, c.eipSynced}
+	cacheSyncs = append(cacheSyncs, c.nodesSynced)
 	if c.gwPodsSynced != nil {
 		cacheSyncs = append(cacheSyncs, c.gwPodsSynced)
 	}

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -27,6 +27,9 @@ const controllerAgentName = "ovn-speaker"
 type Controller struct {
 	config *Configuration
 
+	// nodesLister/nodesSynced are only initialized when EnableLbSvcAnnounce is enabled,
+	// because the node cache is used solely for the local node label gate on Service VIP
+	// announcements.
 	nodesLister listerv1.NodeLister
 	nodesSynced cache.InformerSynced
 

--- a/pkg/speaker/node_route_eip.go
+++ b/pkg/speaker/node_route_eip.go
@@ -318,13 +318,16 @@ func (c *Controller) syncNodeRouteEIPs() error {
 	// Merging both into expectedPrefixes ensures reconcileRoutes does not withdraw
 	// Service VIP routes that are legitimately announced.
 	if c.config.EnableLbSvcAnnounce {
-		services, err := c.servicesLister.List(labels.Everything())
-		if err != nil {
-			return fmt.Errorf("failed to list services for bgp-lb-vip: %w", err)
+		node := c.getLocalNode()
+		if shouldAnnounceLbSvcIngressOnNode(node) {
+			services, err := c.servicesLister.List(labels.Everything())
+			if err != nil {
+				return fmt.Errorf("failed to list services for bgp-lb-vip: %w", err)
+			}
+			expectedBgpLbServiceEip := make(prefixMap)
+			collectSvcBgpPrefixes(services, node, expectedBgpLbServiceEip)
+			mergePrefixMap(expectedBgpLbServiceEip, expectedPrefixes)
 		}
-		expectedBgpLbServiceEip := make(prefixMap)
-		collectSvcBgpPrefixes(services, c.getLocalNode(), expectedBgpLbServiceEip)
-		mergePrefixMap(expectedBgpLbServiceEip, expectedPrefixes)
 	}
 
 	return c.reconcileRoutes(expectedPrefixes)

--- a/pkg/speaker/node_route_eip.go
+++ b/pkg/speaker/node_route_eip.go
@@ -323,7 +323,7 @@ func (c *Controller) syncNodeRouteEIPs() error {
 			return fmt.Errorf("failed to list services for bgp-lb-vip: %w", err)
 		}
 		expectedBgpLbServiceEip := make(prefixMap)
-		collectSvcBgpPrefixes(services, c.config.NodeName, expectedBgpLbServiceEip)
+		collectSvcBgpPrefixes(services, c.getLocalNode(), expectedBgpLbServiceEip)
 		mergePrefixMap(expectedBgpLbServiceEip, expectedPrefixes)
 	}
 

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -106,14 +106,17 @@ func (c *Controller) syncSubnetRoutes() {
 		//
 		// Keep a dedicated set for Service VIP prefixes, then merge into the final expected
 		// prefixes to preserve composability with other announcement sources.
-		expectedBgpLbServiceEip := make(prefixMap)
-		services, err := c.servicesLister.List(labels.Everything())
-		if err != nil {
-			klog.Errorf("failed to list services for bgp-lb-eip, %v", err)
-			return
+		node := c.getLocalNode()
+		if shouldAnnounceLbSvcIngressOnNode(node) {
+			services, err := c.servicesLister.List(labels.Everything())
+			if err != nil {
+				klog.Errorf("failed to list services for bgp-lb-eip, %v", err)
+				return
+			}
+			expectedBgpLbServiceEip := make(prefixMap)
+			collectSvcBgpPrefixes(services, node, expectedBgpLbServiceEip)
+			mergePrefixMap(expectedBgpLbServiceEip, bgpExpected)
 		}
-		collectSvcBgpPrefixes(services, c.getLocalNode(), expectedBgpLbServiceEip)
-		mergePrefixMap(expectedBgpLbServiceEip, bgpExpected)
 	}
 
 	if err := c.reconcileRoutes(bgpExpected); err != nil {
@@ -136,6 +139,9 @@ func mergePrefixMap(src, dst prefixMap) {
 }
 
 func (c *Controller) getLocalNode() *corev1.Node {
+	if c.config.NodeName == "" || c.nodesLister == nil {
+		return nil
+	}
 	node, err := c.nodesLister.Get(c.config.NodeName)
 	if err != nil {
 		klog.Warningf("failed to get local node %s for LB service announcement: %v", c.config.NodeName, err)

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -112,7 +112,7 @@ func (c *Controller) syncSubnetRoutes() {
 			klog.Errorf("failed to list services for bgp-lb-eip, %v", err)
 			return
 		}
-		collectSvcBgpPrefixes(services, c.config.NodeName, expectedBgpLbServiceEip)
+		collectSvcBgpPrefixes(services, c.getLocalNode(), expectedBgpLbServiceEip)
 		mergePrefixMap(expectedBgpLbServiceEip, bgpExpected)
 	}
 
@@ -133,6 +133,19 @@ func mergePrefixMap(src, dst prefixMap) {
 			dst[afi].Insert(prefix)
 		}
 	}
+}
+
+func (c *Controller) getLocalNode() *corev1.Node {
+	node, err := c.nodesLister.Get(c.config.NodeName)
+	if err != nil {
+		klog.Warningf("failed to get local node %s for LB service announcement: %v", c.config.NodeName, err)
+		return nil
+	}
+	return node
+}
+
+func shouldAnnounceLbSvcIngressOnNode(node *corev1.Node) bool {
+	return node != nil && node.Labels[util.BgpSpeakLbVipLabel] == "true"
 }
 
 // collectPodExpectedPrefixes iterates over pods and collects IPs that should be announced via BGP.
@@ -188,6 +201,8 @@ func collectPodExpectedPrefixes(pods []*corev1.Pod, subnetByName map[string]*kub
 
 // collectSvcBgpPrefixes announces external IPs of LoadBalancer Services that carry
 // the ovn.kubernetes.io/bgp annotation and have a non-empty status.loadBalancer.ingress.
+// The current node must first pass the node-level gate
+// ovn.kubernetes.io/bgp-speak-lb-vip=true before any Service-level policy is evaluated.
 //
 // Producer/consumer relationship with the controller:
 //   - Controller side (--enable-bgp-lb-vip): binds a bgp_lb_vip VIP to the Service and
@@ -245,7 +260,12 @@ func collectPodExpectedPrefixes(pods []*corev1.Pod, subnetByName map[string]*kub
 //
 //	TODO: add EndpointSlice-aware local announcement to automatically update
 //	the BGP path on VM live migration. Use bgp=cluster for production until then.
-func collectSvcBgpPrefixes(services []*corev1.Service, nodeName string, bgpExpected prefixMap) {
+func collectSvcBgpPrefixes(services []*corev1.Service, node *corev1.Node, bgpExpected prefixMap) {
+	if !shouldAnnounceLbSvcIngressOnNode(node) {
+		return
+	}
+	nodeName := node.Name
+
 	for _, svc := range services {
 		if len(svc.Annotations) == 0 {
 			continue

--- a/pkg/speaker/subnet.go
+++ b/pkg/speaker/subnet.go
@@ -139,6 +139,7 @@ func mergePrefixMap(src, dst prefixMap) {
 }
 
 func (c *Controller) getLocalNode() *corev1.Node {
+	// The local node cache is only wired when Service VIP announcement is enabled.
 	if c.config.NodeName == "" || c.nodesLister == nil {
 		return nil
 	}

--- a/pkg/speaker/subnet_test.go
+++ b/pkg/speaker/subnet_test.go
@@ -259,20 +259,54 @@ func makeService(name, ns, bgpPolicy string, ingressIPs ...string) *corev1.Servi
 	return svc
 }
 
+func makeNode(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
 func TestCollectSvcBgpPrefixes(t *testing.T) {
 	cases := []struct {
 		name     string
+		node     *corev1.Node
 		services []*corev1.Service
 		wantIPs  []string
 		wantNot  []string
 	}{
 		{
+			name: "node without bgp-speak-lb-vip label: not announced",
+			node: makeNode("node1", map[string]string{
+				util.BgpAnnotation: "true",
+			}),
+			services: []*corev1.Service{makeService("svc1", "default", "true", "1.2.3.4")},
+			wantNot:  []string{"1.2.3.4/32"},
+		},
+		{
+			name: "node with bgp-speak-lb-vip=true label: announced",
+			node: makeNode("node1", map[string]string{
+				util.BgpAnnotation:      "true",
+				util.BgpSpeakLbVipLabel: "true",
+			}),
+			services: []*corev1.Service{makeService("svc1", "default", "true", "1.2.3.4")},
+			wantIPs:  []string{"1.2.3.4/32"},
+		},
+		{
+			name:     "nil node: not announced",
+			services: []*corev1.Service{makeService("svc1", "default", "true", "1.2.3.4")},
+			wantNot:  []string{"1.2.3.4/32"},
+		},
+		{
 			name:     "no annotation: not announced",
+			node:     makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{makeService("svc1", "default", "", "1.2.3.4")},
 			wantNot:  []string{"1.2.3.4/32"},
 		},
 		{
 			name: "bgp annotation without bgp-vip: not announced",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1",
@@ -287,21 +321,25 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 		},
 		{
 			name:     "bgp=true: announced",
+			node:     makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{makeService("svc1", "default", "true", "1.2.3.4")},
 			wantIPs:  []string{"1.2.3.4/32"},
 		},
 		{
 			name:     "bgp=cluster: announced",
+			node:     makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{makeService("svc1", "default", "cluster", "10.0.0.1")},
 			wantIPs:  []string{"10.0.0.1/32"},
 		},
 		{
 			name:     "bgp=local: announced on all nodes for LB service",
+			node:     makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{makeService("svc1", "default", "local", "192.168.100.5")},
 			wantIPs:  []string{"192.168.100.5/32"},
 		},
 		{
 			name: "bgp-speaker-node matches this node: announced (Test Mode)",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1",
@@ -317,7 +355,27 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 			wantIPs: []string{"5.5.5.5/32"},
 		},
 		{
+			name: "bgp-speaker-node matches this node but node lacks bgp-speak-lb-vip label: skipped",
+			node: makeNode("node1", map[string]string{
+				util.BgpAnnotation: "true",
+			}),
+			services: []*corev1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.BgpVipAnnotation:         "vip1",
+						util.BgpSpeakerNodeAnnotation: "node1",
+					},
+				},
+				Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+				Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "5.5.5.5"}}}},
+			}},
+			wantNot: []string{"5.5.5.5/32"},
+		},
+		{
 			name: "bgp-speaker-node does NOT match this node: skipped (Test Mode)",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1",
@@ -333,12 +391,14 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 		},
 		{
 			name:     "no ingress IP: nothing announced",
+			node:     makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{makeService("svc1", "default", "true")},
 			wantNot:  []string{},
 		},
 		// MetalLB compatibility: metallb.universe.tf/allow-shared-ip
 		{
 			name: "MetalLB compat: allow-shared-ip only, no bgp annotations: announced as cluster (Default Mode)",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1",
@@ -354,6 +414,7 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 		},
 		{
 			name: "MetalLB compat: allow-shared-ip present, bgp-vip absent: MetalLB key wins",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1",
@@ -370,6 +431,7 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 		},
 		{
 			name: "MetalLB compat: allow-shared-ip present, bgp-vip also set: MetalLB key takes priority, bgp-vip ignored",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1",
@@ -386,6 +448,7 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 		},
 		{
 			name: "MetalLB compat: allow-shared-ip with bgp-speaker-node matching this node: Test Mode wins",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1",
@@ -402,6 +465,7 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 		},
 		{
 			name: "MetalLB compat: allow-shared-ip with bgp-speaker-node NOT matching: skipped",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "svc1",
@@ -417,6 +481,7 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 		},
 		{
 			name: "multiple services: each contributes independently",
+			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{
 				makeService("svc1", "default", "true", "1.1.1.1"),
 				makeService("svc2", "default", "", "2.2.2.2"),
@@ -440,7 +505,7 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			bgpExpected := make(prefixMap)
-			collectSvcBgpPrefixes(tc.services, "node1", bgpExpected)
+			collectSvcBgpPrefixes(tc.services, tc.node, bgpExpected)
 
 			for _, wantIP := range tc.wantIPs {
 				found := false

--- a/pkg/speaker/subnet_test.go
+++ b/pkg/speaker/subnet_test.go
@@ -338,7 +338,7 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 			wantIPs:  []string{"192.168.100.5/32"},
 		},
 		{
-			name: "bgp=local with node gate closed: not announced",
+			name:     "bgp=local with node gate closed: not announced",
 			node:     makeNode("node1", map[string]string{}),
 			services: []*corev1.Service{makeService("svc1", "default", "local", "192.168.100.5")},
 			wantNot:  []string{"192.168.100.5/32"},

--- a/pkg/speaker/subnet_test.go
+++ b/pkg/speaker/subnet_test.go
@@ -339,9 +339,7 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 		},
 		{
 			name: "bgp=local with node gate closed: not announced",
-			node: makeNode("node1", map[string]string{
-				util.BgpAnnotation: "true",
-			}),
+			node:     makeNode("node1", map[string]string{}),
 			services: []*corev1.Service{makeService("svc1", "default", "local", "192.168.100.5")},
 			wantNot:  []string{"192.168.100.5/32"},
 		},

--- a/pkg/speaker/subnet_test.go
+++ b/pkg/speaker/subnet_test.go
@@ -338,6 +338,14 @@ func TestCollectSvcBgpPrefixes(t *testing.T) {
 			wantIPs:  []string{"192.168.100.5/32"},
 		},
 		{
+			name: "bgp=local with node gate closed: not announced",
+			node: makeNode("node1", map[string]string{
+				util.BgpAnnotation: "true",
+			}),
+			services: []*corev1.Service{makeService("svc1", "default", "local", "192.168.100.5")},
+			wantNot:  []string{"192.168.100.5/32"},
+		},
+		{
 			name: "bgp-speaker-node matches this node: announced (Test Mode)",
 			node: makeNode("node1", map[string]string{util.BgpSpeakLbVipLabel: "true"}),
 			services: []*corev1.Service{{

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -484,6 +484,12 @@ const (
 	// Use for testing or non-ECMP upstreams only. Failover is manual.
 	BgpSpeakerNodeAnnotation = "ovn.kubernetes.io/bgp-speaker-node"
 
+	// BgpSpeakLbVipLabel gates whether the local node's BGP speaker is allowed
+	// to announce LoadBalancer Service ingress IPs via BGP.
+	// This is a node label, separate from BgpAnnotation which controls whether
+	// the bgp-speaker Pod is scheduled onto the node.
+	BgpSpeakLbVipLabel = "ovn.kubernetes.io/bgp-speak-lb-vip"
+
 	// MetalLBAllowSharedIPAnnotation is MetalLB's shared-IP gate annotation.
 	// Its value is the name of the VIP CR; naming it after the IP (e.g. "111.62.241.102")
 	// is a common operational convention but is not required — kube-ovn only checks

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -486,6 +486,9 @@ const (
 
 	// BgpSpeakLbVipLabel gates whether the local node's BGP speaker is allowed
 	// to announce LoadBalancer Service ingress IPs via BGP.
+	// It intentionally uses the Label suffix to match the file-wide naming
+	// convention for labels (for example, NodeNameLabel and VpcNatGatewayLabel),
+	// unlike BgpAnnotation and BgpSpeakerNodeAnnotation which are annotations.
 	// This is a node label, separate from BgpAnnotation which controls whether
 	// the bgp-speaker Pod is scheduled onto the node.
 	BgpSpeakLbVipLabel = "ovn.kubernetes.io/bgp-speak-lb-vip"


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
ovn.kubernetes.io/bgp 用于控制 node 是否部署 bgp-speaker pod。需要添加一个 ovn.kubernetes.io/bgp-speak-lb-vip label, 用于控制是否在该节点宣告 LB ingress 公网 IP。 

纯扩展逻辑，在原来的基础之上添加一次 node ovn.kubernetes.io/bgp-speak-lb-vip == true 的判断即可




<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
