### PR TITLE
feat(speaker): add GoBGP BFD support for fast failure detection (#6912)

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -1,6 +1,31 @@
 # syntax=docker/dockerfile:1
-ARG VERSION
+ARG VERSION=latest
 ARG BASE_TAG=$VERSION
+
+# Intermediate stage: download gobgp CLI binary.
+# Keeps the base image untouched while upgrading third-party binaries.
+FROM ubuntu:24.04 AS qiniu
+ARG ARCH=amd64
+ARG DEBIAN_FRONTEND=noninteractive
+# renovate: datasource=github-releases depName=gobgp packageName=osrg/gobgp versioning=semver
+ARG GOBGP_VERSION=4.6.0
+ARG GOBGP_SHA256_AMD64=6d4491a85dfbaaab8d18bd6855be6b67a117a5a9670eea3ee9f7dddaf50e869c
+ARG GOBGP_SHA256_ARM64=41eb71f4765b3d26fff811cc6b99a91d040c6687c5aa9fc25c7baf3472e2cd66
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+    curl -sSf -L --retry 5 -o /tmp/gobgp.tar.gz \
+    "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/gobgp_${GOBGP_VERSION}_linux_${ARCH}.tar.gz" && \
+    case "$ARCH" in \
+    amd64) EXPECTED_SHA256="$GOBGP_SHA256_AMD64" ;; \
+    arm64) EXPECTED_SHA256="$GOBGP_SHA256_ARM64" ;; \
+    *) echo "unsupported arch: $ARCH"; exit 1 ;; \
+    esac && \
+    echo "${EXPECTED_SHA256}  /tmp/gobgp.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/gobgp.tar.gz -C /usr/bin gobgp && \
+    chmod +x /usr/bin/gobgp && \
+    rm -f /tmp/gobgp.tar.gz && \
+    apt-get purge -y --auto-remove curl && \
+    rm -rf /var/lib/apt/lists/*
+
 FROM kubeovn/kube-ovn-base:$BASE_TAG AS setcap
 
 COPY *.sh /kube-ovn/
@@ -27,6 +52,7 @@ COPY --chmod=0644 logrotate/* /etc/logrotate.d/
 COPY grace_stop_ovn_controller /usr/share/ovn/scripts/grace_stop_ovn_controller
 
 COPY --from=setcap /kube-ovn /kube-ovn
+COPY --from=qiniu /usr/bin/gobgp /usr/bin/gobgp
 RUN /kube-ovn/iptables-wrapper-installer.sh --no-sanity-check
 
 WORKDIR /kube-ovn

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
-	github.com/osrg/gobgp/v4 v4.4.0
+	github.com/osrg/gobgp/v4 v4.6.0
 	github.com/ovn-kubernetes/libovsdb v0.8.1
 	github.com/parnurzeal/gorequest v0.3.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,8 @@ github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
-github.com/osrg/gobgp/v4 v4.4.0 h1:GA0oTZv4WfjXrhHI3Gm/fm9jAy4fVU7vdMvt0GOEqBE=
-github.com/osrg/gobgp/v4 v4.4.0/go.mod h1:pgu8waqTvZUYl4eQuPrKNOaVwhHv7Zt9YymuzCaX7f8=
+github.com/osrg/gobgp/v4 v4.6.0 h1:9ga/Pn3NUiM0Sv0K7YI+dy/uMYKyXOsu3dalXTmnX8I=
+github.com/osrg/gobgp/v4 v4.6.0/go.mod h1:j1GLEuE20jm2YAoGmaHGb3y9lGH/KBgCBT4Ss5RY/wQ=
 github.com/parnurzeal/gorequest v0.3.0 h1:SoFyqCDC9COr1xuS6VA8fC8RU7XyrJZN2ona1kEX7FI=
 github.com/parnurzeal/gorequest v0.3.0/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -35,21 +35,21 @@ build-go-arm:
 
 .PHONY: build-kube-ovn
 build-kube-ovn: build-debug build-go
-	docker build -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) --build-arg VERSION=$(RELEASE_TAG) -f dist/images/Dockerfile dist/images/
-	docker build -t $(REGISTRY)/kube-ovn:$(LEGACY_TAG) --build-arg VERSION=$(LEGACY_TAG) -f dist/images/Dockerfile dist/images/
+	docker build -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) --build-arg VERSION=$(RELEASE_TAG) --build-arg ARCH=amd64 -f dist/images/Dockerfile dist/images/
+#	docker build -t $(REGISTRY)/kube-ovn:$(LEGACY_TAG) --build-arg VERSION=$(LEGACY_TAG) --build-arg ARCH=amd64 -f dist/images/Dockerfile dist/images/
 
 .PHONY: build-kube-ovn-dpdk
 build-kube-ovn-dpdk: build-go
-	docker build -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG)-dpdk --build-arg BASE_TAG=$(RELEASE_TAG)-dpdk -f dist/images/Dockerfile dist/images/
+	docker build -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG)-dpdk --build-arg BASE_TAG=$(RELEASE_TAG)-dpdk --build-arg ARCH=amd64 -f dist/images/Dockerfile dist/images/
 
 .PHONY: build-dev
 build-dev: build-go
-	docker build -t $(REGISTRY)/kube-ovn:$(DEV_TAG) --build-arg VERSION=$(RELEASE_TAG) -f dist/images/Dockerfile dist/images/
+	docker build -t $(REGISTRY)/kube-ovn:$(DEV_TAG) --build-arg VERSION=$(RELEASE_TAG) --build-arg ARCH=amd64 -f dist/images/Dockerfile dist/images/
 
 .PHONY: build-debug
 build-debug:
 	@DEBUG=1 $(MAKE) build-go
-	docker build -t $(REGISTRY)/kube-ovn:$(DEBUG_TAG) --build-arg BASE_TAG=$(DEBUG_TAG) -f dist/images/Dockerfile dist/images/
+	docker build -t $(REGISTRY)/kube-ovn:$(DEBUG_TAG) --build-arg BASE_TAG=$(DEBUG_TAG) --build-arg ARCH=amd64 -f dist/images/Dockerfile dist/images/
 
 .PHONY: base-amd64
 base-amd64:
@@ -68,25 +68,25 @@ base-arm64:
 
 .PHONY: build-kit
 build-kit: build-go
-	DOCKER_BUILDKIT=1 docker build -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) --build-arg VERSION=$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile dist/images/
+	DOCKER_BUILDKIT=1 docker build -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) --build-arg VERSION=$(RELEASE_TAG) --build-arg ARCH=amd64 -o type=docker -f dist/images/Dockerfile dist/images/
 
 .PHONY: image-kube-ovn
-image-kube-ovn: image-kube-ovn-debug build-go
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) --build-arg VERSION=$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile dist/images/
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/kube-ovn:$(LEGACY_TAG) --build-arg VERSION=$(LEGACY_TAG) -o type=docker -f dist/images/Dockerfile dist/images/
+image-kube-ovn: build-go
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) --build-arg VERSION=$(RELEASE_TAG) --build-arg ARCH=amd64 -o type=docker -f dist/images/Dockerfile dist/images/
+#	docker buildx build --platform linux/amd64 -t $(REGISTRY)/kube-ovn:$(LEGACY_TAG) --build-arg VERSION=$(LEGACY_TAG) --build-arg ARCH=amd64 -o type=docker -f dist/images/Dockerfile dist/images/
 
 .PHONY: image-kube-ovn-arm64
 image-kube-ovn-arm64: build-go-arm
-	docker buildx build --platform linux/arm64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) --build-arg VERSION=$(RELEASE_TAG) -o type=docker -f dist/images/Dockerfile dist/images/
+	docker buildx build --platform linux/arm64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG) --build-arg VERSION=$(RELEASE_TAG) --build-arg ARCH=arm64 -o type=docker -f dist/images/Dockerfile dist/images/
 
 .PHONY: image-kube-ovn-debug
 image-kube-ovn-debug:
 	@DEBUG=1 $(MAKE) build-go
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/kube-ovn:$(DEBUG_TAG) --build-arg BASE_TAG=$(DEBUG_TAG) -o type=docker -f dist/images/Dockerfile dist/images/
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/kube-ovn:$(DEBUG_TAG) --build-arg BASE_TAG=$(DEBUG_TAG) --build-arg ARCH=amd64 -o type=docker -f dist/images/Dockerfile dist/images/
 
 .PHONY: image-kube-ovn-dpdk
 image-kube-ovn-dpdk: build-go
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG)-dpdk --build-arg VERSION=$(RELEASE_TAG) --build-arg BASE_TAG=$(RELEASE_TAG)-dpdk -o type=docker -f dist/images/Dockerfile dist/images/
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/kube-ovn:$(RELEASE_TAG)-dpdk --build-arg VERSION=$(RELEASE_TAG) --build-arg BASE_TAG=$(RELEASE_TAG)-dpdk --build-arg ARCH=amd64 -o type=docker -f dist/images/Dockerfile dist/images/
 
 .PHONY: image-vpc-nat-gateway
 image-vpc-nat-gateway:
@@ -114,7 +114,7 @@ release-arm: release-arm-debug image-kube-ovn-arm64
 .PHONY: release-arm-debug
 release-arm-debug:
 	@DEBUG=1 $(MAKE) build-go-arm
-	docker buildx build --platform linux/arm64 -t $(REGISTRY)/kube-ovn:$(DEBUG_TAG) --build-arg BASE_TAG=$(DEBUG_TAG) -o type=docker -f dist/images/Dockerfile dist/images/
+	docker buildx build --platform linux/arm64 -t $(REGISTRY)/kube-ovn:$(DEBUG_TAG) --build-arg BASE_TAG=$(DEBUG_TAG) --build-arg ARCH=arm64 -o type=docker -f dist/images/Dockerfile dist/images/
 
 .PHONY: push-dev
 push-dev:
@@ -126,7 +126,7 @@ push-release: release
 
 .PHONY: tar-kube-ovn
 tar-kube-ovn:
-	docker save $(REGISTRY)/kube-ovn:$(RELEASE_TAG) $(REGISTRY)/kube-ovn:$(LEGACY_TAG) $(REGISTRY)/kube-ovn:$(DEBUG_TAG) -o kube-ovn.tar
+	docker save $(REGISTRY)/kube-ovn:$(RELEASE_TAG) -o kube-ovn.tar
 
 .PHONY: tar-kube-ovn-dpdk
 tar-kube-ovn-dpdk:

--- a/pkg/speaker/bfd.go
+++ b/pkg/speaker/bfd.go
@@ -1,0 +1,89 @@
+package speaker
+
+import (
+	"context"
+
+	"github.com/osrg/gobgp/v4/api"
+	"k8s.io/klog/v2"
+)
+
+// bfdSessionStateString converts a BFD session state enum to a human-readable string.
+func bfdSessionStateString(state api.BfdSessionState) string {
+	switch state {
+	case api.BfdSessionState_BFD_SESSION_STATE_UP:
+		return "UP"
+	case api.BfdSessionState_BFD_SESSION_STATE_DOWN:
+		return "DOWN"
+	case api.BfdSessionState_BFD_SESSION_STATE_INIT:
+		return "INIT"
+	case api.BfdSessionState_BFD_SESSION_STATE_ADMIN_DOWN:
+		return "ADMIN_DOWN"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// logBFDStatus logs the BFD status for all peers.
+// Guarded by klog verbosity to avoid unnecessary gRPC calls when logging is off.
+func (c *Controller) logBFDStatus() {
+	if !c.config.EnableBFD {
+		return
+	}
+
+	// Guard with Enabled() to skip gRPC calls when log level is insufficient.
+	if !klog.V(3).Enabled() {
+		return
+	}
+
+	if stats := c.config.BgpServer.GetBfdServerStats(); stats != nil {
+		hasErrors := stats.ReceivedDrop > 0 || stats.ReceivedError > 0 || stats.InvalidPacket > 0 || stats.UnknownPeer > 0
+		if hasErrors {
+			klog.Warningf("BFD server stats: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d",
+				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
+		} else if c.lastBFDStatsHasErrors {
+			klog.Infof("BFD server stats recovered: received=%d, dropped=%d, errors=%d, invalid=%d, unknownPeer=%d",
+				stats.ReceivedPacket, stats.ReceivedDrop, stats.ReceivedError, stats.InvalidPacket, stats.UnknownPeer)
+		}
+		c.lastBFDStatsHasErrors = hasErrors
+	}
+
+	if c.lastBFDPeerStates == nil {
+		c.lastBFDPeerStates = make(map[string]string)
+	}
+
+	c.config.BgpServer.ListBfdPeer(context.Background(), func(addr string, state *api.BfdPeerState) {
+		if state == nil {
+			klog.Warningf("BFD peer %s: no state available", addr)
+			return
+		}
+
+		current := bfdSessionStateString(state.SessionState)
+		if prev, ok := c.lastBFDPeerStates[addr]; ok && prev == current {
+			return
+		}
+		c.lastBFDPeerStates[addr] = current
+
+		if async := state.BfdAsync; async != nil {
+			klog.Infof("BFD peer %s: state=%s, tx=%d, rx=%d",
+				addr, current, async.TransmittedPackets, async.ReceivedPackets)
+		} else {
+			klog.Infof("BFD peer %s: state=%s", addr, current)
+		}
+	})
+}
+
+// newBFDPeerConfig creates a BfdPeerConfig from the speaker Configuration.
+// Returns nil when BFD is disabled.
+// GoBGP expects BFD intervals in microseconds (RFC 5880), while CLI flags
+// accept milliseconds for user convenience; this function performs the conversion.
+func newBFDPeerConfig(config *Configuration) *api.BfdPeerConfig {
+	if !config.EnableBFD {
+		return nil
+	}
+	return &api.BfdPeerConfig{
+		Enabled:                  true,
+		DesiredMinimumTxInterval: config.BFDMinTX * 1000, // ms → μs
+		RequiredMinimumReceive:   config.BFDMinRX * 1000, // ms → μs
+		DetectionMultiplier:      uint32(config.BFDDetectionMultiplier),
+	}
+}

--- a/pkg/speaker/bfd_test.go
+++ b/pkg/speaker/bfd_test.go
@@ -1,0 +1,231 @@
+package speaker
+
+import (
+	"math"
+	"net"
+	"testing"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBFDPeerConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *Configuration
+		expected *api.BfdPeerConfig
+	}{
+		{
+			name: "BFD disabled returns nil",
+			config: &Configuration{
+				EnableBFD: false,
+			},
+			expected: nil,
+		},
+		{
+			name: "default values converts ms to us",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+			},
+			expected: &api.BfdPeerConfig{
+				Enabled:                  true,
+				DesiredMinimumTxInterval: 1000000, // 1000ms = 1,000,000μs
+				RequiredMinimumReceive:   1000000,
+				DetectionMultiplier:      3,
+			},
+		},
+		{
+			name: "custom values converts ms to us",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               300,
+				BFDMinRX:               500,
+				BFDDetectionMultiplier: 5,
+			},
+			expected: &api.BfdPeerConfig{
+				Enabled:                  true,
+				DesiredMinimumTxInterval: 300000, // 300ms = 300,000μs
+				RequiredMinimumReceive:   500000,
+				DetectionMultiplier:      5,
+			},
+		},
+		{
+			name: "aggressive timers",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               100,
+				BFDMinRX:               100,
+				BFDDetectionMultiplier: 3,
+			},
+			expected: &api.BfdPeerConfig{
+				Enabled:                  true,
+				DesiredMinimumTxInterval: 100000, // 100ms = 100,000μs
+				RequiredMinimumReceive:   100000,
+				DetectionMultiplier:      3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newBFDPeerConfig(tt.config)
+			if tt.expected == nil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.expected.Enabled, got.Enabled)
+			require.Equal(t, tt.expected.DesiredMinimumTxInterval, got.DesiredMinimumTxInterval)
+			require.Equal(t, tt.expected.RequiredMinimumReceive, got.RequiredMinimumReceive)
+			require.Equal(t, tt.expected.DetectionMultiplier, got.DetectionMultiplier)
+		})
+	}
+}
+
+func TestBfdSessionStateString(t *testing.T) {
+	tests := []struct {
+		state    api.BfdSessionState
+		expected string
+	}{
+		{api.BfdSessionState_BFD_SESSION_STATE_UP, "UP"},
+		{api.BfdSessionState_BFD_SESSION_STATE_DOWN, "DOWN"},
+		{api.BfdSessionState_BFD_SESSION_STATE_INIT, "INIT"},
+		{api.BfdSessionState_BFD_SESSION_STATE_ADMIN_DOWN, "ADMIN_DOWN"},
+		{api.BfdSessionState_BFD_SESSION_STATE_UNSPECIFIED, "UNKNOWN"},
+		{api.BfdSessionState(99), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			require.Equal(t, tt.expected, bfdSessionStateString(tt.state))
+		})
+	}
+}
+
+func TestValidateBFDFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Configuration
+		wantErr bool
+	}{
+		{
+			name: "valid BFD config",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: false,
+		},
+		{
+			// Upper bound (255) is enforced by the uint8 type, so no >255 test case is needed.
+			name: "detection multiplier zero",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 0,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero min-tx",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               0,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero min-rx",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               0,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "BFD disabled skips validation",
+			config: &Configuration{
+				EnableBFD:              false,
+				BFDDetectionMultiplier: 255,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: false,
+		},
+		{
+			name: "min-tx at overflow boundary is valid",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               math.MaxUint32 / 1000,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: false,
+		},
+		{
+			name: "min-tx exceeds overflow boundary",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               math.MaxUint32/1000 + 1,
+				BFDMinRX:               1000,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+		{
+			name: "min-rx exceeds overflow boundary",
+			config: &Configuration{
+				EnableBFD:              true,
+				BFDMinTX:               1000,
+				BFDMinRX:               math.MaxUint32/1000 + 1,
+				BFDDetectionMultiplier: 3,
+				NeighborAs:             65001,
+				ClusterAs:              65000,
+				NodeName:               "test-node",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Need at least one neighbor for validation to pass
+			tt.config.NeighborAddresses = []net.IP{net.ParseIP("10.0.0.1")}
+			err := tt.config.validateRequiredFlags()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/speaker/config.go
+++ b/pkg/speaker/config.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"os"
 	"slices"
@@ -70,6 +71,12 @@ type Configuration struct {
 	VpcNatGwNamespace string
 	NodeRouteEIPMode  bool
 
+	// BFD (Bidirectional Forwarding Detection) configuration
+	EnableBFD              bool
+	BFDMinTX               uint32 // minimum transmit interval in milliseconds (converted to microseconds for GoBGP)
+	BFDMinRX               uint32 // minimum receive interval in milliseconds (converted to microseconds for GoBGP)
+	BFDDetectionMultiplier uint8  // RFC 5880 §6.8.1: valid range 1-255
+
 	NodeName       string
 	KubeConfigFile string
 	KubeClient     kubernetes.Interface
@@ -109,6 +116,10 @@ func ParseFlags() (*Configuration, error) {
 		argLogPerm                     = pflag.String("log-perm", "640", "The permission for the log file")
 		argVpcNatGwNamespace           = pflag.String("vpc-nat-gw-namespace", "kube-system", "The namespace where VPC NAT Gateway pods are deployed, default: kube-system")
 		argNodeRouteEIPMode            = pflag.BoolP("node-route-eip-mode", "", false, "Make the BGP speaker announce EIPs for local NAT gateway pods. Mutually exclusive with --nat-gw-mode. Speaker runs on node with host network and announces EIPs for vpc-nat-gw pods on the same node")
+		argEnableBFD                   = pflag.BoolP("enable-bfd", "", false, "Enable BFD (Bidirectional Forwarding Detection) for fast failure detection")
+		argBFDMinTX                    = pflag.Uint32("bfd-min-tx", 1000, "BFD minimum transmit interval in milliseconds (default 1000, max 4294967)")
+		argBFDMinRX                    = pflag.Uint32("bfd-min-rx", 1000, "BFD minimum receive interval in milliseconds (default 1000, max 4294967)")
+		argBFDDetectionMultiplier      = pflag.Uint8("bfd-detection-multiplier", 3, "BFD detection multiplier (default 3, valid range 1-255 per RFC 5880)")
 	)
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
@@ -184,6 +195,10 @@ func ParseFlags() (*Configuration, error) {
 		LogPerm:                     *argLogPerm,
 		VpcNatGwNamespace:           *argVpcNatGwNamespace,
 		NodeRouteEIPMode:            *argNodeRouteEIPMode,
+		EnableBFD:                   *argEnableBFD,
+		BFDMinTX:                    *argBFDMinTX,
+		BFDMinRX:                    *argBFDMinRX,
+		BFDDetectionMultiplier:      *argBFDDetectionMultiplier,
 	}
 
 	if err := config.validateMutuallyExclusiveModes(); err != nil {
@@ -286,6 +301,22 @@ func (config *Configuration) validateRequiredFlags() error {
 	// NodeRouteEIPMode requires NodeName to identify local NAT gateway pods
 	if config.NodeRouteEIPMode && config.NodeName == "" {
 		missingFlags = append(missingFlags, "--node-route-eip-mode requires --node-name to be specified")
+	}
+
+	if config.EnableBFD {
+		if config.BFDDetectionMultiplier == 0 {
+			missingFlags = append(missingFlags, "--bfd-detection-multiplier must be between 1 and 255")
+		}
+		if config.BFDMinTX == 0 {
+			missingFlags = append(missingFlags, "--bfd-min-tx must be > 0")
+		} else if config.BFDMinTX > math.MaxUint32/1000 {
+			missingFlags = append(missingFlags, "--bfd-min-tx must be <= 4294967 ms to avoid uint32 overflow in ms-to-μs conversion")
+		}
+		if config.BFDMinRX == 0 {
+			missingFlags = append(missingFlags, "--bfd-min-rx must be > 0")
+		} else if config.BFDMinRX > math.MaxUint32/1000 {
+			missingFlags = append(missingFlags, "--bfd-min-rx must be <= 4294967 ms to avoid uint32 overflow in ms-to-μs conversion")
+		}
 	}
 
 	if len(missingFlags) > 0 {
@@ -460,6 +491,13 @@ func (config *Configuration) initBgpServer() error {
 				})
 			}
 
+			peer.Bfd = newBFDPeerConfig(config)
+			if peer.Bfd != nil {
+				klog.Infof("BFD enabled for peer %s: MinTX=%dms(%dμs), MinRX=%dms(%dμs), Multiplier=%d",
+					addr.String(), config.BFDMinTX, config.BFDMinTX*1000,
+					config.BFDMinRX, config.BFDMinRX*1000, config.BFDDetectionMultiplier)
+			}
+
 			logBgpPeer(peer)
 			if err := addPeerWithRetry(s, peer); err != nil {
 				err = fmt.Errorf("failed to add peer %s: %w", addr.String(), err)
@@ -499,7 +537,7 @@ func addPeerWithRetry(s *gobgp.BgpServer, peer *api.Peer) error {
 
 // logBgpPeer logs the BGP peer configuration details, masking sensitive information.
 func logBgpPeer(peer *api.Peer) {
-	klog.Infof("BGP Peer Configuration: NeighborAddress=%s, LocalAddress=%s, PeerAsn=%d, HoldTime=%d, PassiveMode=%v, EbgpMultihop=%v, GracefulRestart=%v, AfiSafis=%v",
+	klog.Infof("BGP Peer Configuration: NeighborAddress=%s, LocalAddress=%s, PeerAsn=%d, HoldTime=%d, PassiveMode=%v, EbgpMultihop=%v, GracefulRestart=%v, AfiSafis=%v, BFD=%v",
 		peer.Conf.NeighborAddress,
 		peer.Transport.LocalAddress,
 		peer.Conf.PeerAsn,
@@ -507,7 +545,8 @@ func logBgpPeer(peer *api.Peer) {
 		peer.Transport.PassiveMode,
 		peer.EbgpMultihop,
 		peer.GracefulRestart,
-		peer.AfiSafis)
+		peer.AfiSafis,
+		peer.Bfd)
 }
 
 // watchPeerState monitors BGP peer state changes and logs detailed information
@@ -515,18 +554,27 @@ func logBgpPeer(peer *api.Peer) {
 func (config *Configuration) watchPeerState() {
 	err := config.BgpServer.WatchEvent(context.Background(), gobgp.WatchEventMessageCallbacks{
 		OnPeerUpdate: func(peer *apiutil.WatchEventMessage_PeerEvent, _ time.Time) {
-			if peer == nil {
+			if peer == nil || peer.Type != apiutil.PEER_EVENT_STATE {
 				return
 			}
 			p := peer.Peer
 			neighborAddr := p.Conf.NeighborAddress.String()
-			localAddr := p.Transport.LocalAddress.String()
-			state := p.State.SessionState.String()
-			peerAS := p.Conf.PeerASN
 
-			if peer.Type == apiutil.PEER_EVENT_STATE {
+			var bfdState string
+			if config.EnableBFD {
+				config.BgpServer.ListBfdPeer(context.Background(), func(addr string, st *api.BfdPeerState) {
+					if addr == neighborAddr && st != nil {
+						bfdState = bfdSessionStateString(st.SessionState)
+					}
+				})
+			}
+
+			if bfdState != "" {
+				klog.Infof("BGP peer state changed: neighbor=%s, state=%s, localAddress=%s, peerAS=%d, bfd=%s",
+					neighborAddr, p.State.SessionState, p.Transport.LocalAddress, p.Conf.PeerASN, bfdState)
+			} else {
 				klog.Infof("BGP peer state changed: neighbor=%s, state=%s, localAddress=%s, peerAS=%d",
-					neighborAddr, state, localAddr, peerAS)
+					neighborAddr, p.State.SessionState, p.Transport.LocalAddress, p.Conf.PeerASN)
 			}
 		},
 	}, gobgp.WatchPeer())

--- a/pkg/speaker/controller.go
+++ b/pkg/speaker/controller.go
@@ -62,6 +62,11 @@ type Controller struct {
 	gwPodsInformerFactory  kubeinformers.SharedInformerFactory
 	kubeovnInformerFactory kubeovninformer.SharedInformerFactory
 	recorder               record.EventRecorder
+
+	// lastBFDPeerStates caches the most recent BFD session state per peer address.
+	// Used by logBFDStatus to suppress repeated logs when state is unchanged.
+	lastBFDPeerStates     map[string]string
+	lastBFDStatsHasErrors bool
 }
 
 func NewController(config *Configuration) *Controller {
@@ -247,4 +252,6 @@ func (c *Controller) Reconcile() {
 		// Default: Pod/Subnet/Service VIP announcements without EIP mode.
 		c.syncSubnetRoutes()
 	}
+
+	c.logBFDStatus()
 }

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -229,7 +229,7 @@ func InjectedServiceVariables(service string) (string, string) {
 // For example, if T is v1.Pod, it returns "Pod".
 func ObjectKind[T metav1.Object]() string {
 	typ := reflect.TypeFor[T]()
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 	return typ.Name()


### PR DESCRIPTION
- Add --enable-bfd flag to enable BFD for BGP peers
- Add --bfd-min-tx, --bfd-min-rx (milliseconds) and --bfd-detection-multiplier flags
- Convert milliseconds to microseconds for GoBGP (RFC 5880)
- Add BFD parameter validation (DetectionMultiplier <= 255, intervals > 0)
- Add BFD session status logging in reconcile loop
- Add unit tests for newBFDPeerConfig, bfdSessionStateString, validateBFDFlags

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
