### PR TITLE
Try fix e2e

### DIFF
--- a/.github/workflows/pr-e2e-7niu-release-1.15.yaml
+++ b/.github/workflows/pr-e2e-7niu-release-1.15.yaml
@@ -24,7 +24,13 @@ env:
   # renovate: datasource=github-releases depName=golangci-lint packageName=golangci/golangci-lint
   GOLANGCI_LINT_VERSION: v2.10.1
   JINJANATOR_VERSION: '25.3.1'
+  # qiniu uses a fork-specific branch name, but the code line still tracks the
+  # upstream release-1.15 version semantics.
   TARGET_BRANCH: 7niu-release-1.15
+  # Master e2e parses E2E_BRANCH as a Kube-OVN version gate (release-* only).
+  # The tested image still comes from the current PR tarball; this value is only
+  # used so SkipVersionPriorTo() can classify the branch as release-1.15.
+  MASTER_E2E_BRANCH: release-1.15
   E2E_SOURCE_BRANCH: master
   MASTER_E2E_NAT_GW_IMAGE: docker.io/kubeovn/vpc-nat-gateway:v1.14.25
 
@@ -259,7 +265,9 @@ jobs:
         id: e2e
         working-directory: test/e2e/source
         env:
-          E2E_BRANCH: ${{ env.TARGET_BRANCH }}
+          # test/e2e/source is only the upstream master test harness. The actual
+          # kube-ovn under test is the tar/image built from this PR branch.
+          E2E_BRANCH: ${{ env.MASTER_E2E_BRANCH }}
           E2E_IP_FAMILY: ipv4
           E2E_NETWORK_MODE: overlay
           SUITE_TARGET: ${{ matrix.suite.target }}
@@ -356,7 +364,7 @@ jobs:
         id: e2e
         working-directory: test/e2e/source
         env:
-          E2E_BRANCH: ${{ env.TARGET_BRANCH }}
+          E2E_BRANCH: ${{ env.MASTER_E2E_BRANCH }}
           E2E_IP_FAMILY: ipv4
           E2E_NETWORK_MODE: overlay
         run: make kube-ovn-ha-e2e
@@ -480,7 +488,7 @@ jobs:
         id: e2e_multus
         working-directory: test/e2e/source
         env:
-          E2E_BRANCH: ${{ env.TARGET_BRANCH }}
+          E2E_BRANCH: ${{ env.MASTER_E2E_BRANCH }}
           E2E_IP_FAMILY: ipv4
           E2E_NETWORK_MODE: overlay
         run: make kube-ovn-multus-conformance-e2e
@@ -490,7 +498,7 @@ jobs:
         if: success()
         working-directory: test/e2e/source
         env:
-          E2E_BRANCH: ${{ env.TARGET_BRANCH }}
+          E2E_BRANCH: ${{ env.MASTER_E2E_BRANCH }}
           E2E_IP_FAMILY: ipv4
           E2E_NETWORK_MODE: overlay
         run: make iptables-vpc-nat-gw-conformance-e2e

--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -3113,8 +3113,10 @@ spec:
                           dstIPs:
                             type: string
                 u2oFeatures:
+                  description: Feature configurations for underlay to overlay interconnection.
                   properties:
                     overlayOnlyRouting:
+                      description: OverlayOnlyRouting controls whether only overlay CIDRs use U2O routing.
                       type: boolean
                   type: object
                 u2oInterconnection:

--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -3112,6 +3112,11 @@ spec:
                             type: string
                           dstIPs:
                             type: string
+                u2oFeatures:
+                  properties:
+                    overlayOnlyRouting:
+                      type: boolean
+                  type: object
                 u2oInterconnection:
                   description: Enable underlay to overlay interconnection.
                   type: boolean

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -3114,6 +3114,13 @@ spec:
                             type: string
                           dstIPs:
                             type: string
+                u2oFeatures:
+                  description: Feature configurations for underlay to overlay interconnection.
+                  properties:
+                    overlayOnlyRouting:
+                      description: OverlayOnlyRouting controls whether only overlay CIDRs use U2O routing.
+                      type: boolean
+                  type: object
                 u2oInterconnection:
                   description: Enable underlay to overlay interconnection.
                   type: boolean

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3372,6 +3372,11 @@ spec:
                             type: string
                           dstIPs:
                             type: string
+                u2oFeatures:
+                  properties:
+                    overlayOnlyRouting:
+                      type: boolean
+                  type: object
                 u2oInterconnection:
                   description: Enable underlay to overlay interconnection.
                   type: boolean

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -3373,8 +3373,10 @@ spec:
                           dstIPs:
                             type: string
                 u2oFeatures:
+                  description: Feature configurations for underlay to overlay interconnection.
                   properties:
                     overlayOnlyRouting:
+                      description: OverlayOnlyRouting controls whether only overlay CIDRs use U2O routing.
                       type: boolean
                   type: object
                 u2oInterconnection:

--- a/pkg/apis/kubeovn/v1/subnet.go
+++ b/pkg/apis/kubeovn/v1/subnet.go
@@ -81,16 +81,21 @@ type SubnetSpec struct {
 
 	NatOutgoingPolicyRules []NatOutgoingPolicyRule `json:"natOutgoingPolicyRules,omitempty"`
 
-	U2OInterconnectionIP    string `json:"u2oInterconnectionIP,omitempty"`
-	U2OInterconnection      bool   `json:"u2oInterconnection,omitempty"`
-	EnableLb                *bool  `json:"enableLb,omitempty"`
-	EnableEcmp              bool   `json:"enableEcmp,omitempty"`
-	EnableMulticastSnoop    bool   `json:"enableMulticastSnoop,omitempty"`
-	EnableExternalLBAddress bool   `json:"enableExternalLBAddress,omitempty"`
+	U2OInterconnectionIP    string      `json:"u2oInterconnectionIP,omitempty"`
+	U2OInterconnection      bool        `json:"u2oInterconnection,omitempty"`
+	U2OFeatures             U2OFeatures `json:"u2oFeatures,omitempty"`
+	EnableLb                *bool       `json:"enableLb,omitempty"`
+	EnableEcmp              bool        `json:"enableEcmp,omitempty"`
+	EnableMulticastSnoop    bool        `json:"enableMulticastSnoop,omitempty"`
+	EnableExternalLBAddress bool        `json:"enableExternalLBAddress,omitempty"`
 
 	RouteTable         string                 `json:"routeTable,omitempty"`
 	NamespaceSelectors []metav1.LabelSelector `json:"namespaceSelectors,omitempty"`
 	NodeNetwork        string                 `json:"nodeNetwork,omitempty"`
+}
+
+type U2OFeatures struct {
+	OverlayOnlyRouting bool `json:"overlayOnlyRouting,omitempty"`
 }
 
 type ACL struct {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -49,6 +49,7 @@ type fakeControllerInformers struct {
 	serviceInformer   coreinformers.ServiceInformer
 	namespaceInformer coreinformers.NamespaceInformer
 	podInformer       coreinformers.PodInformer
+	nodeInformer      coreinformers.NodeInformer
 }
 
 type fakeController struct {
@@ -148,6 +149,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 	serviceInformer := kubeInformerFactory.Core().V1().Services()
 	namespaceInformer := kubeInformerFactory.Core().V1().Namespaces()
 	podInformer := kubeInformerFactory.Core().V1().Pods()
+	nodeInformer := kubeInformerFactory.Core().V1().Nodes()
 
 	nadInformerFactory := nadinformers.NewSharedInformerFactory(nadClient, 0)
 	nadInformer := nadInformerFactory.K8sCniCncfIo().V1().NetworkAttachmentDefinitions()
@@ -168,6 +170,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		serviceInformer:   serviceInformer,
 		namespaceInformer: namespaceInformer,
 		podInformer:       podInformer,
+		nodeInformer:      nodeInformer,
 	}
 
 	// Create mock OVN clients
@@ -180,6 +183,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		servicesLister:          serviceInformer.Lister(),
 		namespacesLister:        namespaceInformer.Lister(),
 		podsLister:              podInformer.Lister(),
+		nodesLister:             nodeInformer.Lister(),
 		vpcsLister:              vpcInformer.Lister(),
 		vpcSynced:               alwaysReady,
 		subnetsLister:           subnetInformer.Lister(),

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -73,6 +73,10 @@ func readyToRemoveFinalizer(subnet *kubeovnv1.Subnet) bool {
 	return false
 }
 
+func u2oOverlayOnlyRoutingEnabled(subnet *kubeovnv1.Subnet) bool {
+	return subnet != nil && subnet.Spec.U2OFeatures.OverlayOnlyRouting
+}
+
 func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 	oldSubnet := oldObj.(*kubeovnv1.Subnet)
 	newSubnet := newObj.(*kubeovnv1.Subnet)
@@ -84,7 +88,42 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 		return
 	}
 
-	if !reflect.DeepEqual(oldSubnet.Spec, newSubnet.Spec) {
+	if oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection {
+		klog.Infof("enqueue update vpc %s triggered by u2o interconnection change of subnet %s", newSubnet.Spec.Vpc, key)
+		c.addOrUpdateVpcQueue.Add(newSubnet.Spec.Vpc)
+	}
+
+	if oldSubnet.Spec.Private != newSubnet.Spec.Private ||
+		oldSubnet.Spec.CIDRBlock != newSubnet.Spec.CIDRBlock ||
+		!slices.Equal(oldSubnet.Spec.AllowSubnets, newSubnet.Spec.AllowSubnets) ||
+		!slices.Equal(oldSubnet.Spec.Namespaces, newSubnet.Spec.Namespaces) ||
+		oldSubnet.Spec.GatewayType != newSubnet.Spec.GatewayType ||
+		!reflect.DeepEqual(oldSubnet.Spec.U2OFeatures, newSubnet.Spec.U2OFeatures) ||
+		oldSubnet.Spec.GatewayNode != newSubnet.Spec.GatewayNode ||
+		oldSubnet.Spec.LogicalGateway != newSubnet.Spec.LogicalGateway ||
+		oldSubnet.Spec.Gateway != newSubnet.Spec.Gateway ||
+		!slices.Equal(oldSubnet.Spec.ExcludeIps, newSubnet.Spec.ExcludeIps) ||
+		!slices.Equal(oldSubnet.Spec.Vips, newSubnet.Spec.Vips) ||
+		oldSubnet.Spec.Vlan != newSubnet.Spec.Vlan ||
+		oldSubnet.Spec.EnableDHCP != newSubnet.Spec.EnableDHCP ||
+		oldSubnet.Spec.DHCPv4Options != newSubnet.Spec.DHCPv4Options ||
+		oldSubnet.Spec.DHCPv6Options != newSubnet.Spec.DHCPv6Options ||
+		oldSubnet.Spec.EnableIPv6RA != newSubnet.Spec.EnableIPv6RA ||
+		oldSubnet.Spec.IPv6RAConfigs != newSubnet.Spec.IPv6RAConfigs ||
+		oldSubnet.Spec.Protocol != newSubnet.Spec.Protocol ||
+		(oldSubnet.Spec.EnableLb == nil && newSubnet.Spec.EnableLb != nil) ||
+		(oldSubnet.Spec.EnableLb != nil && newSubnet.Spec.EnableLb == nil) ||
+		(oldSubnet.Spec.EnableLb != nil && newSubnet.Spec.EnableLb != nil && *oldSubnet.Spec.EnableLb != *newSubnet.Spec.EnableLb) ||
+		oldSubnet.Spec.EnableEcmp != newSubnet.Spec.EnableEcmp ||
+		!reflect.DeepEqual(oldSubnet.Spec.Acls, newSubnet.Spec.Acls) ||
+		oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection ||
+		oldSubnet.Spec.RouteTable != newSubnet.Spec.RouteTable ||
+		oldSubnet.Spec.Vpc != newSubnet.Spec.Vpc ||
+		oldSubnet.Spec.NatOutgoing != newSubnet.Spec.NatOutgoing ||
+		oldSubnet.Spec.EnableMulticastSnoop != newSubnet.Spec.EnableMulticastSnoop ||
+		!reflect.DeepEqual(oldSubnet.Spec.NatOutgoingPolicyRules, newSubnet.Spec.NatOutgoingPolicyRules) ||
+		!reflect.DeepEqual(oldSubnet.Spec.NamespaceSelectors, newSubnet.Spec.NamespaceSelectors) ||
+		(newSubnet.Spec.U2OInterconnection && newSubnet.Spec.U2OInterconnectionIP != "" && oldSubnet.Spec.U2OInterconnectionIP != newSubnet.Spec.U2OInterconnectionIP) {
 		klog.V(3).Infof("enqueue update subnet %s", key)
 
 		if oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection {
@@ -829,6 +868,12 @@ func (c *Controller) handleDeleteSubnet(subnet *kubeovnv1.Subnet) error {
 		klog.Errorf("failed to delete policy route for overlay subnet %s, %v", subnet.Name, err)
 		return err
 	}
+	if subnet.Spec.Vlan == "" {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, subnet.Name); err != nil {
+			klog.Errorf("sync u2o overlay cidrs address set for deleted subnet %s failed, %v", subnet.Name, err)
+			return err
+		}
+	}
 
 	err := c.handleDeleteLogicalSwitch(subnet.Name)
 	if err != nil {
@@ -916,6 +961,12 @@ func (c *Controller) reconcileSubnet(subnet *kubeovnv1.Subnet) error {
 	if err := c.reconcileVips(subnet); err != nil {
 		klog.Errorf("reconcile vips for subnet %s failed, %v", subnet.Name, err)
 		return err
+	}
+	if subnet.Spec.Vlan == "" {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, ""); err != nil {
+			klog.Errorf("sync u2o overlay cidrs address set for subnet %s failed, %v", subnet.Name, err)
+			return err
+		}
 	}
 	return nil
 }
@@ -2330,8 +2381,12 @@ func (c *Controller) deletePolicyRouteByGatewayType(subnet *kubeovnv1.Subnet, ga
 
 func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) error {
 	v4Gw, v6Gw := util.SplitStringIP(subnet.Spec.Gateway)
+	overlayOnly := u2oOverlayOnlyRoutingEnabled(subnet)
 
 	externalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{"isU2ORoutePolicy": "true"})
+
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
 
 	nodes, err := c.nodesLister.List(labels.Everything())
 	if err != nil {
@@ -2350,9 +2405,6 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			nodesIPv6 = append(nodesIPv6, nodeIPv6)
 		}
 	}
-
-	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
-	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
 
 	if err := c.OVNNbClient.CreateAddressSet(u2oExcludeIP4Ag, externalIDs); err != nil {
 		klog.Errorf("create address set %s: %v", u2oExcludeIP4Ag, err)
@@ -2378,35 +2430,55 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 		}
 	}
 
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	if overlayOnly {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, ""); err != nil {
+			return err
+		}
+	}
+
+	overlayOnlyExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{
+		"isU2ORoutePolicy":            "true",
+		"isU2OOverlayOnlyRoutePolicy": "true",
+	})
+	desiredPolicies := make(map[string]struct{})
+
 	for cidrBlock := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
 		ipSuffix := getIPSuffix(util.CheckProtocol(cidrBlock))
 		nextHop := v4Gw
-		U2OexcludeIPAs := u2oExcludeIP4Ag
+		u2oExcludeIPAs := u2oExcludeIP4Ag
+		overlayCIDRsAg := overlayCIDRs4Ag
 		if ipSuffix == "ip6" {
 			nextHop = v6Gw
-			U2OexcludeIPAs = u2oExcludeIP6Ag
+			u2oExcludeIPAs = u2oExcludeIP6Ag
+			overlayCIDRsAg = overlayCIDRs6Ag
 		}
 
 		match1 := fmt.Sprintf("%s.dst == %s", ipSuffix, cidrBlock)
-		match2 := fmt.Sprintf("%s.dst == $%s && %s.src == %s", ipSuffix, U2OexcludeIPAs, ipSuffix, cidrBlock)
+		match2 := fmt.Sprintf("%s.dst == $%s && %s.src == %s", ipSuffix, u2oExcludeIPAs, ipSuffix, cidrBlock)
 		match3 := fmt.Sprintf("%s.src == %s", ipSuffix, cidrBlock)
+		matchSameSubnet := fmt.Sprintf("%s.src == %s && %s.dst == %s", ipSuffix, cidrBlock, ipSuffix, cidrBlock)
+		matchOverlayToUnderlay := fmt.Sprintf("%s.src == $%s && %s.dst == %s", ipSuffix, overlayCIDRsAg, ipSuffix, cidrBlock)
 
-		/*
-			policy1:
-			priority 29400 match: "ip4.dst == underlay subnet cidr"                         action: allow
-
-			policy2:
-			priority 31000 match: "ip4.dst == node ips && ip4.src == underlay subnet cidr"  action: reroute physical gw
-
-			policy3:
-			priority 29000 match: "ip4.src == underlay subnet cidr"                         action: reroute physical gw
-
-			comment:
-			policy1 and policy2 allow overlay pod access underlay but when overlay pod access node ip, it should go join subnet,
-			policy3: underlay pod first access u2o interconnection lrp and then reroute to physical gw
-		*/
 		action := kubeovnv1.PolicyRouteActionAllow
-		if subnet.Spec.Vpc == c.config.ClusterRouter {
+		if overlayOnly {
+			klog.Infof("add u2o overlay only policy for router: %s, match %s, action %s", subnet.Spec.Vpc, matchOverlayToUnderlay, action)
+			if err := c.addPolicyRouteToVpc(
+				subnet.Spec.Vpc,
+				&kubeovnv1.PolicyRoute{
+					Priority: util.U2OSubnetPolicyPriority,
+					Match:    matchOverlayToUnderlay,
+					Action:   action,
+				},
+				overlayOnlyExternalIDs,
+			); err != nil {
+				klog.Errorf("failed to add u2o overlay to underlay policy for subnet %s %v", subnet.Name, err)
+				return err
+			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSubnetPolicyPriority, matchOverlayToUnderlay)] = struct{}{}
+		}
+
+		if !overlayOnly && subnet.Spec.Vpc == c.config.ClusterRouter {
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match1, action)
 			if err := c.addPolicyRouteToVpc(
 				subnet.Spec.Vpc,
@@ -2420,9 +2492,16 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 				klog.Errorf("failed to add u2o interconnection policy1 for subnet %s %v", subnet.Name, err)
 				return err
 			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSubnetPolicyPriority, match1)] = struct{}{}
+		}
 
+		if overlayOnly || subnet.Spec.Vpc == c.config.ClusterRouter {
 			action = kubeovnv1.PolicyRouteActionReroute
 			klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s", subnet.Spec.Vpc, match2, action)
+			currentExternalIDs := externalIDs
+			if overlayOnly {
+				currentExternalIDs = overlayOnlyExternalIDs
+			}
 			if err := c.addPolicyRouteToVpc(
 				subnet.Spec.Vpc,
 				&kubeovnv1.PolicyRoute{
@@ -2431,19 +2510,41 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 					Action:    action,
 					NextHopIP: nextHop,
 				},
-				externalIDs,
+				currentExternalIDs,
 			); err != nil {
 				klog.Errorf("failed to add u2o interconnection policy2 for subnet %s %v", subnet.Name, err)
 				return err
 			}
+			desiredPolicies[logicalRouterPolicyKey(util.SubnetRouterPolicyPriority, match2)] = struct{}{}
+		}
+
+		if overlayOnly {
+			klog.Infof("add u2o overlay only same-subnet policy for router: %s, match %s, action %s", subnet.Spec.Vpc, matchSameSubnet, kubeovnv1.PolicyRouteActionAllow)
+			if err := c.addPolicyRouteToVpc(
+				subnet.Spec.Vpc,
+				&kubeovnv1.PolicyRoute{
+					Priority: util.U2OSameSubnetPolicyPriority,
+					Match:    matchSameSubnet,
+					Action:   kubeovnv1.PolicyRouteActionAllow,
+				},
+				overlayOnlyExternalIDs,
+			); err != nil {
+				klog.Errorf("failed to add u2o overlay only same-subnet policy for subnet %s %v", subnet.Name, err)
+				return err
+			}
+			desiredPolicies[logicalRouterPolicyKey(util.U2OSameSubnetPolicyPriority, matchSameSubnet)] = struct{}{}
 		}
 
 		action = kubeovnv1.PolicyRouteActionReroute
+		physicalGatewayPolicyPriority := util.GatewayRouterPolicyPriority
+		if overlayOnly {
+			physicalGatewayPolicyPriority = util.U2OPhysicalGatewayPolicyPriority
+		}
 		klog.Infof("add u2o interconnection policy for router: %s, match %s, action %s, nexthop %s", subnet.Spec.Vpc, match3, action, nextHop)
 		if err := c.addPolicyRouteToVpc(
 			subnet.Spec.Vpc,
 			&kubeovnv1.PolicyRoute{
-				Priority:  util.GatewayRouterPolicyPriority,
+				Priority:  physicalGatewayPolicyPriority,
 				Match:     match3,
 				Action:    action,
 				NextHopIP: nextHop,
@@ -2451,6 +2552,116 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 			externalIDs,
 		); err != nil {
 			klog.Errorf("failed to add u2o interconnection policy3 for subnet %s %v", subnet.Name, err)
+			return err
+		}
+		desiredPolicies[logicalRouterPolicyKey(physicalGatewayPolicyPriority, match3)] = struct{}{}
+	}
+	if err := c.deleteStaleU2ORoutePolicies(subnet, desiredPolicies); err != nil {
+		return err
+	}
+	return nil
+}
+
+func logicalRouterPolicyKey(priority int, match string) string {
+	return fmt.Sprintf("%d/%s", priority, match)
+}
+
+func u2oOverlayCIDRsAddressSetNames(vpcName string) (string, string) {
+	v4Name := strings.ReplaceAll(fmt.Sprintf(util.U2OOverlayCIDRs, vpcName, "ip4"), "-", ".")
+	v6Name := strings.ReplaceAll(fmt.Sprintf(util.U2OOverlayCIDRs, vpcName, "ip6"), "-", ".")
+	return v4Name, v6Name
+}
+
+func u2oOverlayCIDRsAddressSetExternalIDs(vpcName string) map[string]string {
+	return map[string]string{
+		"isU2OOverlayCIDRs": "true",
+		"vpc":               vpcName,
+	}
+}
+
+func (c *Controller) syncU2OOverlayCIDRsAddressSet(vpcName, excludeSubnet string) (v4CIDRs, v6CIDRs []string, err error) {
+	if vpcName == "" {
+		return nil, nil, nil
+	}
+
+	v4Name, v6Name := u2oOverlayCIDRsAddressSetNames(vpcName)
+	externalIDs := u2oOverlayCIDRsAddressSetExternalIDs(vpcName)
+	if v4CIDRs, v6CIDRs, err = c.buildU2OOverlayCIDRs(vpcName, excludeSubnet); err != nil {
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.CreateAddressSet(v4Name, externalIDs); err != nil {
+		klog.Errorf("create address set %s: %v", v4Name, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.CreateAddressSet(v6Name, externalIDs); err != nil {
+		klog.Errorf("create address set %s: %v", v6Name, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.AddressSetUpdateAddress(v4Name, v4CIDRs...); err != nil {
+		klog.Errorf("set v4 address set %s with address %v: %v", v4Name, v4CIDRs, err)
+		return nil, nil, err
+	}
+	if err := c.OVNNbClient.AddressSetUpdateAddress(v6Name, v6CIDRs...); err != nil {
+		klog.Errorf("set v6 address set %s with address %v: %v", v6Name, v6CIDRs, err)
+		return nil, nil, err
+	}
+	return v4CIDRs, v6CIDRs, nil
+}
+
+func (c *Controller) buildU2OOverlayCIDRs(vpcName, excludeSubnet string) (v4CIDRs, v6CIDRs []string, err error) {
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets: %v", err)
+		return nil, nil, err
+	}
+
+	for _, subnet := range subnets {
+		if subnet.Name == excludeSubnet || subnet.Spec.Vpc != vpcName || subnet.Spec.Vlan != "" {
+			continue
+		}
+		for cidr := range strings.SplitSeq(subnet.Spec.CIDRBlock, ",") {
+			switch util.CheckProtocol(cidr) {
+			case kubeovnv1.ProtocolIPv4:
+				v4CIDRs = append(v4CIDRs, cidr)
+			case kubeovnv1.ProtocolIPv6:
+				v6CIDRs = append(v6CIDRs, cidr)
+			}
+		}
+	}
+	return v4CIDRs, v6CIDRs, nil
+}
+
+func (c *Controller) deleteStaleU2ORoutePolicies(subnet *kubeovnv1.Subnet, desiredPolicies map[string]struct{}) error {
+	lr := subnet.Status.U2OInterconnectionVPC
+	if lr == "" {
+		lr = subnet.Spec.Vpc
+	}
+
+	logicalRouter, err := c.OVNNbClient.GetLogicalRouter(lr, true)
+	if err == nil && logicalRouter == nil {
+		klog.Infof("logical router %s already deleted", lr)
+		return nil
+	}
+
+	policies, err := c.OVNNbClient.ListLogicalRouterPolicies(lr, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true)
+	if err != nil {
+		klog.Errorf("failed to list u2o logical router policies: %v", err)
+		return err
+	}
+	for _, policy := range policies {
+		if policy.ExternalIDs["isU2ONoLBRoutePolicy"] == "true" {
+			continue
+		}
+		if _, ok := desiredPolicies[logicalRouterPolicyKey(policy.Priority, policy.Match)]; ok {
+			continue
+		}
+		klog.Infof("delete stale u2o policy for router %s with match %s priority %d", lr, policy.Match, policy.Priority)
+		if err := c.OVNNbClient.DeleteLogicalRouterPolicyByUUID(lr, policy.UUID); err != nil {
+			klog.Errorf("failed to delete stale u2o policy for subnet %s: %v", subnet.Name, err)
 			return err
 		}
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -93,6 +93,9 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 		c.addOrUpdateVpcQueue.Add(newSubnet.Spec.Vpc)
 	}
 
+	// Only fields reconciled by the subnet controller trigger a subnet requeue.
+	// Other spec fields are handled by their own control paths and intentionally
+	// stay out of this whitelist to match upstream behavior.
 	if oldSubnet.Spec.Private != newSubnet.Spec.Private ||
 		oldSubnet.Spec.CIDRBlock != newSubnet.Spec.CIDRBlock ||
 		!slices.Equal(oldSubnet.Spec.AllowSubnets, newSubnet.Spec.AllowSubnets) ||
@@ -2638,7 +2641,11 @@ func (c *Controller) deleteStaleU2ORoutePolicies(subnet *kubeovnv1.Subnet, desir
 	}
 
 	logicalRouter, err := c.OVNNbClient.GetLogicalRouter(lr, true)
-	if err == nil && logicalRouter == nil {
+	if err != nil {
+		klog.Errorf("failed to get logical router %s: %v", lr, err)
+		return err
+	}
+	if logicalRouter == nil {
 		klog.Infof("logical router %s already deleted", lr)
 		return nil
 	}

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -103,6 +103,7 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 		oldSubnet.Spec.GatewayType != newSubnet.Spec.GatewayType ||
 		!reflect.DeepEqual(oldSubnet.Spec.U2OFeatures, newSubnet.Spec.U2OFeatures) ||
 		oldSubnet.Spec.GatewayNode != newSubnet.Spec.GatewayNode ||
+		!reflect.DeepEqual(oldSubnet.Spec.GatewayNodeSelectors, newSubnet.Spec.GatewayNodeSelectors) ||
 		oldSubnet.Spec.LogicalGateway != newSubnet.Spec.LogicalGateway ||
 		oldSubnet.Spec.Gateway != newSubnet.Spec.Gateway ||
 		!slices.Equal(oldSubnet.Spec.ExcludeIps, newSubnet.Spec.ExcludeIps) ||
@@ -119,6 +120,7 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 		(oldSubnet.Spec.EnableLb != nil && newSubnet.Spec.EnableLb != nil && *oldSubnet.Spec.EnableLb != *newSubnet.Spec.EnableLb) ||
 		oldSubnet.Spec.EnableEcmp != newSubnet.Spec.EnableEcmp ||
 		!reflect.DeepEqual(oldSubnet.Spec.Acls, newSubnet.Spec.Acls) ||
+		oldSubnet.Spec.AllowEWTraffic != newSubnet.Spec.AllowEWTraffic ||
 		oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection ||
 		oldSubnet.Spec.RouteTable != newSubnet.Spec.RouteTable ||
 		oldSubnet.Spec.Vpc != newSubnet.Spec.Vpc ||

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -88,14 +88,15 @@ func (c *Controller) enqueueUpdateSubnet(oldObj, newObj any) {
 		return
 	}
 
-	if oldSubnet.Spec.U2OInterconnection != newSubnet.Spec.U2OInterconnection {
-		klog.Infof("enqueue update vpc %s triggered by u2o interconnection change of subnet %s", newSubnet.Spec.Vpc, key)
-		c.addOrUpdateVpcQueue.Add(newSubnet.Spec.Vpc)
-	}
-
+	// Intentionally excluded spec fields:
+	// - Default, Provider, Mtu, DisableGatewayCheck, NodeNetwork:
+	//   creation-time or pod-side semantics, not reconciled here.
+	// - EnableExternalLBAddress, ExternalEgressGateway, PolicyRoutingPriority,
+	//   PolicyRoutingTableID, DisableInterConnection:
+	//   handled by other control paths outside the subnet controller queue.
 	// Only fields reconciled by the subnet controller trigger a subnet requeue.
-	// Other spec fields are handled by their own control paths and intentionally
-	// stay out of this whitelist to match upstream behavior.
+	// Keep this whitelist and the coverage test in subnet_test.go in sync when
+	// SubnetSpec changes.
 	if oldSubnet.Spec.Private != newSubnet.Spec.Private ||
 		oldSubnet.Spec.CIDRBlock != newSubnet.Spec.CIDRBlock ||
 		!slices.Equal(oldSubnet.Spec.AllowSubnets, newSubnet.Spec.AllowSubnets) ||
@@ -2440,6 +2441,10 @@ func (c *Controller) addPolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) err
 		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, ""); err != nil {
 			return err
 		}
+	} else {
+		if _, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, subnet.Name); err != nil {
+			return err
+		}
 	}
 
 	overlayOnlyExternalIDs := buildPolicyRouteExternalIDs(subnet.Name, map[string]string{
@@ -2584,6 +2589,35 @@ func u2oOverlayCIDRsAddressSetExternalIDs(vpcName string) map[string]string {
 	}
 }
 
+func (c *Controller) deleteU2OOverlayCIDRsAddressSet(vpcName string) error {
+	if vpcName == "" {
+		return nil
+	}
+	v4Name, v6Name := u2oOverlayCIDRsAddressSetNames(vpcName)
+	if err := c.OVNNbClient.DeleteAddressSet(v4Name, v6Name); err != nil {
+		klog.Errorf("delete u2o overlay cidrs address set for vpc %s: %v", vpcName, err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) shouldKeepU2OOverlayCIDRsAddressSet(vpcName, excludeSubnet string) (bool, error) {
+	subnets, err := c.subnetsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list subnets: %v", err)
+		return false, err
+	}
+	for _, subnet := range subnets {
+		if subnet.Name == excludeSubnet || subnet.Spec.Vpc != vpcName || subnet.Spec.Vlan == "" {
+			continue
+		}
+		if subnet.Spec.U2OInterconnection && u2oOverlayOnlyRoutingEnabled(subnet) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (c *Controller) syncU2OOverlayCIDRsAddressSet(vpcName, excludeSubnet string) (v4CIDRs, v6CIDRs []string, err error) {
 	if vpcName == "" {
 		return nil, nil, nil
@@ -2591,8 +2625,18 @@ func (c *Controller) syncU2OOverlayCIDRsAddressSet(vpcName, excludeSubnet string
 
 	v4Name, v6Name := u2oOverlayCIDRsAddressSetNames(vpcName)
 	externalIDs := u2oOverlayCIDRsAddressSetExternalIDs(vpcName)
+	keepAddressSet, err := c.shouldKeepU2OOverlayCIDRsAddressSet(vpcName, excludeSubnet)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !keepAddressSet {
+		return nil, nil, c.deleteU2OOverlayCIDRsAddressSet(vpcName)
+	}
 	if v4CIDRs, v6CIDRs, err = c.buildU2OOverlayCIDRs(vpcName, excludeSubnet); err != nil {
 		return nil, nil, err
+	}
+	if len(v4CIDRs) == 0 && len(v6CIDRs) == 0 {
+		return nil, nil, c.deleteU2OOverlayCIDRsAddressSet(vpcName)
 	}
 	if err := c.OVNNbClient.CreateAddressSet(v4Name, externalIDs); err != nil {
 		klog.Errorf("create address set %s: %v", v4Name, err)
@@ -2678,8 +2722,12 @@ func (c *Controller) deleteStaleU2ORoutePolicies(subnet *kubeovnv1.Subnet, desir
 }
 
 func (c *Controller) deletePolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) error {
+	cleanupOverlayCIDRs := func() error {
+		_, _, err := c.syncU2OOverlayCIDRsAddressSet(subnet.Spec.Vpc, subnet.Name)
+		return err
+	}
 	if !c.logicalRouterExists(subnet.Spec.Vpc) {
-		return nil
+		return cleanupOverlayCIDRs()
 	}
 	policies, err := c.OVNNbClient.ListLogicalRouterPolicies(subnet.Spec.Vpc, -1, map[string]string{
 		"isU2ORoutePolicy": "true",
@@ -2691,7 +2739,7 @@ func (c *Controller) deletePolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) 
 		return err
 	}
 	if len(policies) == 0 {
-		return nil
+		return cleanupOverlayCIDRs()
 	}
 
 	lr := subnet.Status.U2OInterconnectionVPC
@@ -2721,7 +2769,7 @@ func (c *Controller) deletePolicyRouteForU2OInterconn(subnet *kubeovnv1.Subnet) 
 		return err
 	}
 
-	return nil
+	return cleanupOverlayCIDRs()
 }
 
 func (c *Controller) addCustomVPCStaticRouteForSubnet(subnet *kubeovnv1.Subnet) error {

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,140 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func TestAddPolicyRouteForU2OInterconn_OverlayOnlyRouting(t *testing.T) {
+	t.Parallel()
+
+	const (
+		subnetName  = "subnet-a"
+		overlayName = "overlay-a"
+		vlanName    = "vlan1"
+		cidr        = "10.16.1.0/24"
+		overlayCIDR = "10.244.0.0/16"
+		gateway     = "10.16.1.1"
+	)
+
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:                util.DefaultVpc,
+			Vlan:               vlanName,
+			CIDRBlock:          cidr,
+			Gateway:            gateway,
+			U2OInterconnection: true,
+			U2OFeatures: kubeovnv1.U2OFeatures{
+				OverlayOnlyRouting: true,
+			},
+		},
+		Status: kubeovnv1.SubnetStatus{
+			U2OInterconnectionVPC: util.DefaultVpc,
+		},
+	}
+	overlaySubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: overlayName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       util.DefaultVpc,
+			CIDRBlock: overlayCIDR,
+		},
+	}
+
+	fc := newFakeController(t)
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(subnet))
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(overlaySubnet))
+
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	overlayExternalIDs := u2oOverlayCIDRsAddressSetExternalIDs(subnet.Spec.Vpc)
+	overlayPolicyExternalIDs := map[string]string{
+		"vendor":                      util.CniTypeName,
+		"subnet":                      subnet.Name,
+		"isU2ORoutePolicy":            "true",
+		"isU2OOverlayOnlyRoutePolicy": "true",
+	}
+	routeExternalIDs := map[string]string{
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+		"isU2ORoutePolicy": "true",
+	}
+
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP4Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP6Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs4Ag, overlayExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs6Ag, overlayExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs4Ag, overlayCIDR).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs6Ag).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSubnetPolicyPriority, fmt.Sprintf("ip4.src == $%s && ip4.dst == %s", overlayCIDRs4Ag, cidr), string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.SubnetRouterPolicyPriority, fmt.Sprintf("ip4.dst == $%s && ip4.src == %s", u2oExcludeIP4Ag, cidr), string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSameSubnetPolicyPriority, fmt.Sprintf("ip4.src == %s && ip4.dst == %s", cidr, cidr), string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), overlayPolicyExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OPhysicalGatewayPolicyPriority, fmt.Sprintf("ip4.src == %s", cidr), string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().GetLogicalRouter(util.DefaultVpc, true).Return(&ovnnb.LogicalRouter{Name: util.DefaultVpc}, nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies(util.DefaultVpc, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true).Return(nil, nil)
+
+	err := ctrl.addPolicyRouteForU2OInterconn(subnet)
+	require.NoError(t, err)
+}
+
+func TestSyncU2OOverlayCIDRsAddressSet_UpdatesAfterOverlaySubnetDeletion(t *testing.T) {
+	t.Parallel()
+
+	const (
+		vpcName      = util.DefaultVpc
+		overlayAName = "overlay-a"
+		overlayBName = "overlay-b"
+		underlayName = "underlay-a"
+		overlayAV4   = "10.244.0.0/16"
+		overlayAV6   = "fd00:244::/64"
+		overlayBV4   = "10.245.0.0/16"
+		overlayBV6   = "fd00:245::/64"
+		underlayCIDR = "10.16.1.0/24"
+		underlayVlan = "vlan1"
+	)
+
+	overlayA := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: overlayAName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, CIDRBlock: overlayAV4 + "," + overlayAV6}}
+	overlayB := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: overlayBName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, CIDRBlock: overlayBV4 + "," + overlayBV6}}
+	underlay := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: underlayName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, Vlan: underlayVlan, CIDRBlock: underlayCIDR}}
+
+	fc := newFakeController(t)
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(overlayA))
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(overlayB))
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(underlay))
+
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(vpcName)
+	overlayExternalIDs := u2oOverlayCIDRsAddressSetExternalIDs(vpcName)
+
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs4Ag, overlayExternalIDs).Return(nil).Times(2)
+	mockOvnClient.EXPECT().CreateAddressSet(overlayCIDRs6Ag, overlayExternalIDs).Return(nil).Times(2)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs4Ag, gomock.Any(), gomock.Any()).DoAndReturn(func(_ string, addresses ...string) error {
+		require.ElementsMatch(t, []string{overlayAV4, overlayBV4}, addresses)
+		return nil
+	})
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs6Ag, gomock.Any(), gomock.Any()).DoAndReturn(func(_ string, addresses ...string) error {
+		require.ElementsMatch(t, []string{overlayAV6, overlayBV6}, addresses)
+		return nil
+	})
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs4Ag, overlayAV4).Return(nil)
+	mockOvnClient.EXPECT().AddressSetUpdateAddress(overlayCIDRs6Ag, overlayAV6).Return(nil)
+
+	v4CIDRs, v6CIDRs, err := ctrl.syncU2OOverlayCIDRsAddressSet(vpcName, "")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{overlayAV4, overlayBV4}, v4CIDRs)
+	require.ElementsMatch(t, []string{overlayAV6, overlayBV6}, v6CIDRs)
+
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Delete(overlayB))
+	v4CIDRs, v6CIDRs, err = ctrl.syncU2OOverlayCIDRsAddressSet(vpcName, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{overlayAV4}, v4CIDRs)
+	require.Equal(t, []string{overlayAV6}, v6CIDRs)
+}
 
 func Test_reconcileVips(t *testing.T) {
 	t.Parallel()

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,6 +16,87 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+func TestSubnetSpecFieldsCoveredByEnqueueUpdateSubnetClassification(t *testing.T) {
+	t.Parallel()
+
+	whitelist := map[string]struct{}{
+		"Private":                {},
+		"CIDRBlock":              {},
+		"AllowSubnets":           {},
+		"Namespaces":             {},
+		"GatewayType":            {},
+		"U2OFeatures":            {},
+		"GatewayNode":            {},
+		"GatewayNodeSelectors":   {},
+		"LogicalGateway":         {},
+		"Gateway":                {},
+		"ExcludeIps":             {},
+		"Vips":                   {},
+		"Vlan":                   {},
+		"EnableDHCP":             {},
+		"DHCPv4Options":          {},
+		"DHCPv6Options":          {},
+		"EnableIPv6RA":           {},
+		"IPv6RAConfigs":          {},
+		"Protocol":               {},
+		"EnableLb":               {},
+		"EnableEcmp":             {},
+		"Acls":                   {},
+		"AllowEWTraffic":         {},
+		"U2OInterconnection":     {},
+		"RouteTable":             {},
+		"Vpc":                    {},
+		"NatOutgoing":            {},
+		"EnableMulticastSnoop":   {},
+		"NatOutgoingPolicyRules": {},
+		"NamespaceSelectors":     {},
+		"U2OInterconnectionIP":   {},
+	}
+	excluded := map[string]struct{}{
+		"Default":                 {},
+		"Provider":                {},
+		"ExternalEgressGateway":   {},
+		"PolicyRoutingPriority":   {},
+		"PolicyRoutingTableID":    {},
+		"Mtu":                     {},
+		"DisableGatewayCheck":     {},
+		"DisableInterConnection":  {},
+		"EnableExternalLBAddress": {},
+		"NodeNetwork":             {},
+	}
+
+	covered := make(map[string]string, len(whitelist)+len(excluded))
+	for field := range whitelist {
+		covered[field] = "whitelist"
+	}
+	for field := range excluded {
+		if prev, ok := covered[field]; ok {
+			t.Fatalf("SubnetSpec field %s is classified twice: %s and excluded", field, prev)
+		}
+		covered[field] = "excluded"
+	}
+
+	specType := reflect.TypeOf(kubeovnv1.SubnetSpec{})
+	actual := make(map[string]struct{}, specType.NumField())
+	for i := 0; i < specType.NumField(); i++ {
+		field := specType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		actual[field.Name] = struct{}{}
+		if _, ok := covered[field.Name]; !ok {
+			t.Fatalf("SubnetSpec field %s is not classified for enqueueUpdateSubnet", field.Name)
+		}
+	}
+
+	for field := range covered {
+		if _, ok := actual[field]; !ok {
+			t.Fatalf("classified field %s does not exist in SubnetSpec", field)
+		}
+	}
+	require.Len(t, covered, len(actual))
+}
 
 func TestAddPolicyRouteForU2OInterconn_OverlayOnlyRouting(t *testing.T) {
 	t.Parallel()
@@ -113,7 +195,18 @@ func TestSyncU2OOverlayCIDRsAddressSet_UpdatesAfterOverlaySubnetDeletion(t *test
 
 	overlayA := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: overlayAName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, CIDRBlock: overlayAV4 + "," + overlayAV6}}
 	overlayB := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: overlayBName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, CIDRBlock: overlayBV4 + "," + overlayBV6}}
-	underlay := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{Name: underlayName}, Spec: kubeovnv1.SubnetSpec{Vpc: vpcName, Vlan: underlayVlan, CIDRBlock: underlayCIDR}}
+	underlay := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: underlayName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:                vpcName,
+			Vlan:               underlayVlan,
+			CIDRBlock:          underlayCIDR,
+			U2OInterconnection: true,
+			U2OFeatures: kubeovnv1.U2OFeatures{
+				OverlayOnlyRouting: true,
+			},
+		},
+	}
 
 	fc := newFakeController(t)
 	ctrl := fc.fakeController
@@ -148,6 +241,90 @@ func TestSyncU2OOverlayCIDRsAddressSet_UpdatesAfterOverlaySubnetDeletion(t *test
 	require.NoError(t, err)
 	require.Equal(t, []string{overlayAV4}, v4CIDRs)
 	require.Equal(t, []string{overlayAV6}, v6CIDRs)
+
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Delete(overlayA))
+	mockOvnClient.EXPECT().DeleteAddressSet(overlayCIDRs4Ag, overlayCIDRs6Ag).Return(nil)
+	v4CIDRs, v6CIDRs, err = ctrl.syncU2OOverlayCIDRsAddressSet(vpcName, "")
+	require.NoError(t, err)
+	require.Nil(t, v4CIDRs)
+	require.Nil(t, v6CIDRs)
+}
+
+func TestAddPolicyRouteForU2OInterconn_DisablesOverlayOnlyRoutingCleansStalePolicies(t *testing.T) {
+	t.Parallel()
+
+	const (
+		subnetName  = "subnet-a"
+		vlanName    = "vlan1"
+		cidr        = "10.16.1.0/24"
+		overlayCIDR = "10.244.0.0/16"
+		gateway     = "10.16.1.1"
+	)
+
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: subnetName},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:                util.DefaultVpc,
+			Vlan:               vlanName,
+			CIDRBlock:          cidr,
+			Gateway:            gateway,
+			U2OInterconnection: true,
+		},
+		Status: kubeovnv1.SubnetStatus{
+			U2OInterconnectionVPC: util.DefaultVpc,
+		},
+	}
+	overlaySubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "overlay-a"},
+		Spec: kubeovnv1.SubnetSpec{
+			Vpc:       util.DefaultVpc,
+			CIDRBlock: overlayCIDR,
+		},
+	}
+
+	fc := newFakeController(t)
+	ctrl := fc.fakeController
+	mockOvnClient := fc.mockOvnClient
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(subnet))
+	require.NoError(t, fc.fakeInformers.subnetInformer.Informer().GetStore().Add(overlaySubnet))
+
+	u2oExcludeIP4Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip4"), "-", ".")
+	u2oExcludeIP6Ag := strings.ReplaceAll(fmt.Sprintf(util.U2OExcludeIPAg, subnet.Name, "ip6"), "-", ".")
+	overlayCIDRs4Ag, overlayCIDRs6Ag := u2oOverlayCIDRsAddressSetNames(subnet.Spec.Vpc)
+	routeExternalIDs := map[string]string{
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+		"isU2ORoutePolicy": "true",
+	}
+
+	match1 := fmt.Sprintf("ip4.dst == %s", cidr)
+	match2 := fmt.Sprintf("ip4.dst == $%s && ip4.src == %s", u2oExcludeIP4Ag, cidr)
+	match3 := fmt.Sprintf("ip4.src == %s", cidr)
+	matchSameSubnet := fmt.Sprintf("ip4.src == %s && ip4.dst == %s", cidr, cidr)
+	matchOverlayToUnderlay := fmt.Sprintf("ip4.src == $%s && ip4.dst == %s", overlayCIDRs4Ag, cidr)
+
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP4Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().CreateAddressSet(u2oExcludeIP6Ag, routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().DeleteAddressSet(overlayCIDRs4Ag, overlayCIDRs6Ag).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.U2OSubnetPolicyPriority, match1, string(kubeovnv1.PolicyRouteActionAllow), ([]string)(nil), ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.SubnetRouterPolicyPriority, match2, string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().AddLogicalRouterPolicy(util.DefaultVpc, util.GatewayRouterPolicyPriority, match3, string(kubeovnv1.PolicyRouteActionReroute), []string{gateway}, ([]string)(nil), routeExternalIDs).Return(nil)
+	mockOvnClient.EXPECT().GetLogicalRouter(util.DefaultVpc, true).Return(&ovnnb.LogicalRouter{Name: util.DefaultVpc}, nil)
+	mockOvnClient.EXPECT().ListLogicalRouterPolicies(util.DefaultVpc, -1, map[string]string{
+		"isU2ORoutePolicy": "true",
+		"vendor":           util.CniTypeName,
+		"subnet":           subnet.Name,
+	}, true).Return([]*ovnnb.LogicalRouterPolicy{
+		{UUID: "overlay-allow", Priority: util.U2OSubnetPolicyPriority, Match: matchOverlayToUnderlay},
+		{UUID: "overlay-same-subnet", Priority: util.U2OSameSubnetPolicyPriority, Match: matchSameSubnet},
+		{UUID: "overlay-gw", Priority: util.U2OPhysicalGatewayPolicyPriority, Match: match3},
+	}, nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "overlay-allow").Return(nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "overlay-same-subnet").Return(nil)
+	mockOvnClient.EXPECT().DeleteLogicalRouterPolicyByUUID(util.DefaultVpc, "overlay-gw").Return(nil)
+
+	err := ctrl.addPolicyRouteForU2OInterconn(subnet)
+	require.NoError(t, err)
 }
 
 func Test_reconcileVips(t *testing.T) {

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -257,6 +257,8 @@ const (
 	U2OSubnetPolicyPriority          = 29400
 	OvnICPolicyPriority              = 29500
 	NodeRouterPolicyPriority         = 30000
+	U2OPhysicalGatewayPolicyPriority = 30050
+	U2OSameSubnetPolicyPriority      = 30060
 	NodeLocalDNSPolicyPriority       = 30100
 	SubnetRouterPolicyPriority       = 31000
 
@@ -301,6 +303,7 @@ const (
 
 	U2OInterconnName = "u2o-interconnection.%s.%s"
 	U2OExcludeIPAg   = "%s.u2o_exclude_ip.%s"
+	U2OOverlayCIDRs  = "%s.u2o_overlay_cidrs.%s"
 
 	McastQuerierName = "mcast-querier.%s"
 

--- a/pkg/util/validator.go
+++ b/pkg/util/validator.go
@@ -173,6 +173,15 @@ func ValidateSubnet(subnet kubeovnv1.Subnet) error {
 		return errors.New("logicalGateway and u2oInterconnection can't be opened at the same time")
 	}
 
+	if subnet.Spec.U2OFeatures.OverlayOnlyRouting {
+		if !subnet.Spec.U2OInterconnection {
+			return errors.New("u2oFeatures.overlayOnlyRouting can only be enabled when u2OInterconnection is true")
+		}
+		if subnet.Spec.Vlan == "" {
+			return errors.New("u2oFeatures.overlayOnlyRouting can only be enabled on underlay subnets (vlan must be set)")
+		}
+	}
+
 	if len(subnet.Spec.NatOutgoingPolicyRules) != 0 {
 		if err := validateNatOutgoingPolicyRules(subnet); err != nil {
 			klog.Error(err)

--- a/pkg/util/validator_test.go
+++ b/pkg/util/validator_test.go
@@ -262,6 +262,73 @@ func TestValidateSubnet(t *testing.T) {
 			err: "logicalGateway and u2oInterconnection can't be opened at the same time",
 		},
 		{
+			name: "U2OOverlayOnlyRoutingWithoutU2OErr",
+			subnet: kubeovnv1.Subnet{
+				TypeMeta: metav1.TypeMeta{Kind: "Subnet", APIVersion: "kubeovn.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-without-u2o",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:     true,
+					Vpc:         "ovn-cluster",
+					Protocol:    kubeovnv1.ProtocolIPv4,
+					CIDRBlock:   "10.16.0.0/16",
+					Gateway:     "10.16.0.1",
+					Provider:    "ovn",
+					GatewayType: kubeovnv1.GWDistributedType,
+					Vlan:        "vlan1",
+					U2OFeatures: kubeovnv1.U2OFeatures{OverlayOnlyRouting: true},
+				},
+				Status: kubeovnv1.SubnetStatus{},
+			},
+			err: "u2oFeatures.overlayOnlyRouting can only be enabled when u2OInterconnection is true",
+		},
+		{
+			name: "U2OOverlayOnlyRoutingWithoutVlanErr",
+			subnet: kubeovnv1.Subnet{
+				TypeMeta: metav1.TypeMeta{Kind: "Subnet", APIVersion: "kubeovn.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-without-vlan",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:            true,
+					Vpc:                "ovn-cluster",
+					Protocol:           kubeovnv1.ProtocolIPv4,
+					CIDRBlock:          "10.16.0.0/16",
+					Gateway:            "10.16.0.1",
+					Provider:           "ovn",
+					GatewayType:        kubeovnv1.GWDistributedType,
+					U2OInterconnection: true,
+					U2OFeatures:        kubeovnv1.U2OFeatures{OverlayOnlyRouting: true},
+				},
+				Status: kubeovnv1.SubnetStatus{},
+			},
+			err: "u2oFeatures.overlayOnlyRouting can only be enabled on underlay subnets (vlan must be set)",
+		},
+		{
+			name: "U2OOverlayOnlyRoutingCorrect",
+			subnet: kubeovnv1.Subnet{
+				TypeMeta: metav1.TypeMeta{Kind: "Subnet", APIVersion: "kubeovn.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ut-u2o-overlay-only-routing-correct",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Default:            true,
+					Vpc:                "ovn-cluster",
+					Protocol:           kubeovnv1.ProtocolIPv4,
+					CIDRBlock:          "10.16.0.0/16",
+					Gateway:            "10.16.0.1",
+					Provider:           "ovn",
+					GatewayType:        kubeovnv1.GWDistributedType,
+					Vlan:               "vlan1",
+					U2OInterconnection: true,
+					U2OFeatures:        kubeovnv1.U2OFeatures{OverlayOnlyRouting: true},
+				},
+				Status: kubeovnv1.SubnetStatus{},
+			},
+			err: "",
+		},
+		{
 			name: "ValidateNatOutgoingPolicyRulesErr",
 			subnet: kubeovnv1.Subnet{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

处理 e2e 失败问题：

https://github.com/qiniu/kube-ovn/actions/runs/28517469708/job/84533787076?pr=58


```bash


Summarizing 3 Failures:
  [FAIL] [CNI:Kube-OVN] [group:rlr] [It] should create Service and Endpoints for selector mode, update on scale, and clean up on delete [Conformance] [Conformance]
  /home/runner/work/kube-ovn/kube-ovn/test/e2e/source/test/e2e/kube-ovn/router_lb_rule/router_lb_rule.go:339
  [FAIL] [CNI:Kube-OVN] [group:service-cidr] [It] should propagate a runtime ServiceCIDR object into node ipsets and remove it on deletion [Conformance] [Conformance]
  /home/runner/work/kube-ovn/kube-ovn/test/e2e/source/test/e2e/kube-ovn/service_cidr/service_cidr.go:99
  [FAIL] [CNI:Kube-OVN] [group:underlay] [It] should support U2O overlay only routing [Conformance] [Serial, Conformance]
  /home/runner/work/kube-ovn/kube-ovn/test/e2e/source/test/e2e/kube-ovn/underlay/underlay.go:1204

Ran 97 of 641 Specs in 1384.106 seconds
FAIL! -- 94 Passed | 3 Failed | 0 Pending | 544 Skipped


```



- Features
- Bug fixes


```bash


**最终结论**

- 这 3 个失败已经按“该修代码的修代码、该 skip 的修 CI”分别处理完。
- 处理方式不是一刀切，因为 3 条失败的根因不同。

**逐条对应**

- `underlay.go:1204`
  - 失败用例：`should support U2O overlay only routing`
  - 根因：当前分支缺少 upstream `release-1.15` 已有的 `U2O overlayOnlyRouting` 能力
  - 正确处理：**从 upstream `release-1.15` 回合修复**
  - 已处理提交：`e05d8b45`
  - 依据：该提交是正式 cherry-pick upstream `release-1.15` 的 `b4437b98`，patch-id 已核对一致
  - 验证：`go test ./...` 通过，`make lint` 通过

- `router_lb_rule.go:339`
  - 失败用例：`should create Service and Endpoints for selector mode, update on scale, and clean up on delete`
  - 根因：这是 upstream master e2e 的 **1.17+ 用例**，在 1.15 上本应被 `SkipVersionPriorTo(1,17)` 跳过；但 CI 给 master e2e 传了 `7niu-release-1.15`，测试框架无法识别为标准 release 版本，导致 skip 失效
  - 正确处理：**修 CI 传参，让它 skip**
  - 不应该处理为：回合 `RouterLBRule` 业务能力到 1.15
  - 已处理提交：`6e297a38`

- `service_cidr.go:99`
  - 失败用例：`should propagate a runtime ServiceCIDR object into node ipsets and remove it on deletion`
  - 根因：和上面同类，也是 upstream master e2e 的 **1.17+ 语义**，在 1.15 上本应 skip，但因为 `E2E_BRANCH` 传值不规范，skip 失效
  - 正确处理：**修 CI 传参，让它 skip**
  - 不应该处理为：回合 `ServiceCIDR` 业务能力到 1.15
  - 已处理提交：`6e297a38`

**为什么这样处理是对的**

- `underlay` 这条是 **当前分支相对 upstream `release-1.15` 的能力缺口**
  - upstream `release-1.15` 已经有 `u2oFeatures.overlayOnlyRouting`
  - 所以应当从 `release-1.15` 回合
- `router_lb_rule` / `service_cidr` 这两条不是能力缺口
  - 它们是 **master e2e 被错误执行在 1.15 上**
  - 所以应当恢复版本门禁，而不是强行把 1.17 特性塞回 1.15

**最终落地的两个提交**

- `e05d8b45`
  - `feat: backport u2o overlay only routing to release-1.15 (#6751)`
  - 用途：修 `underlay`
- `6e297a38`
  - `ci: normalize master e2e branch for 1.15 skip logic`
  - 用途：让 `router_lb_rule` / `service_cidr` 在 1.15 上正确 skip

**一句话总结**

- 第 3 条 `underlay`：**回合 upstream `release-1.15` 修复**
- 前 2 条 `router_lb_rule` / `service_cidr`：**修 CI，让不该跑的 master e2e 正确 skip**
```


<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
