### PR TITLE
feat: support share type iptables DNAT with nft map-based LB

### DIFF
--- a/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
+++ b/charts/kube-ovn-v2/crds/kube-ovn-crd.yaml
@@ -1684,6 +1684,9 @@ spec:
         - jsonPath: .spec.internalPort
           name: InternalPort
           type: string
+        - jsonPath: .spec.type
+          name: Type
+          type: string
         - jsonPath: .status.natGwDp
           name: NatGwDp
           type: string
@@ -1766,6 +1769,13 @@ spec:
                 internalPort:
                   type: string
                   description: Internal port number to forward traffic to
+                type:
+                  type: string
+                  description: 'DNAT rule type: exclusive (default, single iptables DNAT for 1:1 port forwarding) or share (nftables map-based load balancing across multiple backends)'
+                  enum:
+                    - exclusive
+                    - share
+                  default: exclusive
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/kube-ovn/templates/kube-ovn-crd.yaml
+++ b/charts/kube-ovn/templates/kube-ovn-crd.yaml
@@ -1684,6 +1684,9 @@ spec:
       - jsonPath: .spec.internalPort
         name: InternalPort
         type: string
+      - jsonPath: .spec.type
+        name: Type
+        type: string
       - jsonPath: .status.natGwDp
         name: NatGwDp
         type: string
@@ -1766,6 +1769,13 @@ spec:
                 internalPort:
                   type: string
                   description: Internal port number to forward traffic to
+                type:
+                  type: string
+                  description: 'DNAT rule type: exclusive (default, single iptables DNAT for 1:1 port forwarding) or share (nftables map-based load balancing across multiple backends)'
+                  enum:
+                    - exclusive
+                    - share
+                  default: exclusive
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/dist/images/install.sh
+++ b/dist/images/install.sh
@@ -1943,6 +1943,9 @@ spec:
       - jsonPath: .spec.internalPort
         name: InternalPort
         type: string
+      - jsonPath: .spec.type
+        name: Type
+        type: string
       - jsonPath: .status.natGwDp
         name: NatGwDp
         type: string
@@ -2025,6 +2028,13 @@ spec:
                 internalPort:
                   type: string
                   description: Internal port number to forward traffic to
+                type:
+                  type: string
+                  description: 'DNAT rule type: exclusive (default, single iptables DNAT for 1:1 port forwarding) or share (nftables map-based load balancing across multiple backends)'
+                  enum:
+                    - exclusive
+                    - share
+                  default: exclusive
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/dist/images/vpcnatgateway/Dockerfile
+++ b/dist/images/vpcnatgateway/Dockerfile
@@ -7,6 +7,7 @@ RUN set -ex \
     bash \
     iproute2 \
     iptables iptables-legacy \
+    nftables \
     iputils \
     tcpdump \
     netcat-openbsd \

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -635,6 +635,7 @@ function del_nft_dnat_map() {
     # Delete a share-type DNAT identity entirely.
     # Removes vmap element + flushes and deletes per-identity chain.
     # Format: eip,dport,protocol
+    check_inited
 
     # Check if table exists (global precondition): if absent there is nothing to delete
     # for any rule, so return early. Kept outside the loop so a missing table does not

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -620,6 +620,9 @@ function add_nft_dnat_map() {
         # 2. Flush + re-add dispatch rule in base chain
         #    (base chain is share-dnat-exclusive; flush wipes any other rule in it, see NFT_PREROUTING_CHAIN)
         # 3. Flush per-identity chain + add new dnat rule
+        #    (the `meta l4proto $nft_proto` match is technically redundant here, since a packet
+        #     only reaches this chain via the vmap key that already selects by protocol; it is
+        #     kept for parity with kube-proxy's per-service dnat rule and as an explicit guard)
         # 4. Ensure vmap element points to this chain
         if ! nft_transaction \
             "add table ip $NFT_TABLE" \

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -516,6 +516,10 @@ function del_dnat() {
 
 NFT_TABLE="kube-ovn"
 NFT_SERVICES_MAP="service-ips"
+# WARNING: this base chain is owned exclusively by the share-dnat feature. add_nft_dnat_map
+# flushes it on every add/update and re-adds its single vmap dispatch rule, so any other rule
+# injected into this chain would be silently wiped. Do NOT reuse NFT_PREROUTING_CHAIN for other
+# components; add a separate chain (or a different priority hook) if new prerouting rules are needed.
 NFT_PREROUTING_CHAIN="prerouting"
 
 # Generate a per-identity chain name from eip:port:protocol.
@@ -614,6 +618,7 @@ function add_nft_dnat_map() {
         # Atomic transaction:
         # 1. Ensure table, base chain, vmap exist (idempotent)
         # 2. Flush + re-add dispatch rule in base chain
+        #    (base chain is share-dnat-exclusive; flush wipes any other rule in it, see NFT_PREROUTING_CHAIN)
         # 3. Flush per-identity chain + add new dnat rule
         # 4. Ensure vmap element points to this chain
         if ! nft_transaction \

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -611,6 +611,15 @@ function del_nft_dnat_map() {
     # Delete a share-type DNAT identity entirely.
     # Removes vmap element + flushes and deletes per-identity chain.
     # Format: eip,dport,protocol
+
+    # Check if table exists (global precondition): if absent there is nothing to delete
+    # for any rule, so return early. Kept outside the loop so a missing table does not
+    # silently skip the remaining rules in a batch call.
+    if ! nft list table ip $NFT_TABLE >/dev/null 2>&1; then
+        echo "NFT table $NFT_TABLE does not exist, nothing to delete"
+        return 0
+    fi
+
     for rule in "$@"
     do
         IFS=',' read -r eip dport protocol <<< "$rule"
@@ -618,12 +627,6 @@ function del_nft_dnat_map() {
         if [ -z "$eip" ] || [ -z "$dport" ] || [ -z "$protocol" ]; then
             echo "Error: invalid nft-dnat-map identity: $rule"
             exit 1
-        fi
-
-        # Check if table exists
-        if ! nft list table ip $NFT_TABLE >/dev/null 2>&1; then
-            echo "NFT table $NFT_TABLE does not exist, nothing to delete"
-            return 0
         fi
 
         local identity_chain nft_proto

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -555,7 +555,7 @@ function add_nft_dnat_map() {
         fi
 
         # Parse backends and count them
-        IFS=';' read -ra backend_list <<< "$backends"
+        IFS='@' read -ra backend_list <<< "$backends"
         local count=${#backend_list[@]}
 
         if [ "$count" -eq 0 ]; then
@@ -1655,37 +1655,40 @@ function eip_egress_qos_del() {
 }
 
 
-rules=${@:2:${#}}
 opt=$1
+shift
 case $opt in
     init)
         # get user interfaces if provided from input
-        interfaces="$rules"
-        init "$interfaces"
+        # Use "$*" so manual invocations like `init net1, net2` (with whitespace
+        # after the comma, as documented in show_help) get re-joined into a single
+        # comma-separated argument. Controller-driven calls always pass a single
+        # pre-joined arg, so behavior is unchanged for them.
+        init "$*"
         ;;
     subnet-route-add)
-        echo "subnet-route-add $rules"
-        add_vpc_internal_route $rules
+        echo "subnet-route-add $*"
+        add_vpc_internal_route "$@"
         ;;
     subnet-route-del)
-        echo "subnet-route-del $rules"
-        del_vpc_internal_route $rules
+        echo "subnet-route-del $*"
+        del_vpc_internal_route "$@"
         ;;
     eip-add)
-        echo "eip-add $rules"
-        add_eip $rules
+        echo "eip-add $*"
+        add_eip "$@"
         ;;
     eip-del)
-        echo "eip-del $rules"
-        del_eip $rules
+        echo "eip-del $*"
+        del_eip "$@"
         ;;
     dnat-add)
-        echo "dnat-add $rules"
-        add_dnat $rules
+        echo "dnat-add $*"
+        add_dnat "$@"
         ;;
     dnat-del)
-        echo "dnat-del $rules"
-        del_dnat $rules
+        echo "dnat-del $*"
+        del_dnat "$@"
         ;;
     nft-dnat-map-add)
         echo "nft-dnat-map-add $*"
@@ -1696,51 +1699,51 @@ case $opt in
         del_nft_dnat_map "$@"
         ;;
     snat-add)
-        echo "snat-add $rules"
-        add_snat $rules
+        echo "snat-add $*"
+        add_snat "$@"
         ;;
     snat-del)
-        echo "snat-del $rules"
-        del_snat $rules
+        echo "snat-del $*"
+        del_snat "$@"
         ;;
     floating-ip-add)
-        echo "floating-ip-add $rules"
-        add_floating_ip $rules
+        echo "floating-ip-add $*"
+        add_floating_ip "$@"
         ;;
     floating-ip-del)
-        echo "floating-ip-del $rules"
-        del_floating_ip $rules
+        echo "floating-ip-del $*"
+        del_floating_ip "$@"
         ;;
     get-iptables-version)
-        echo "get-iptables-version $rules"
-        get_iptables_version $rules
+        echo "get-iptables-version $*"
+        get_iptables_version "$@"
         ;;
     help|--help|-h)
         show_help
         ;;
     eip-ingress-qos-add)
-        echo "eip-ingress-qos-add $rules"
-        eip_ingress_qos_add $rules
+        echo "eip-ingress-qos-add $*"
+        eip_ingress_qos_add "$@"
         ;;
     eip-egress-qos-add)
-        echo "eip-egress-qos-add $rules"
-        eip_egress_qos_add $rules
+        echo "eip-egress-qos-add $*"
+        eip_egress_qos_add "$@"
         ;;
     eip-ingress-qos-del)
-        echo "eip-ingress-qos-del $rules"
-        eip_ingress_qos_del $rules
+        echo "eip-ingress-qos-del $*"
+        eip_ingress_qos_del "$@"
         ;;
     eip-egress-qos-del)
-        echo "eip-egress-qos-del $rules"
-        eip_egress_qos_del $rules
+        echo "eip-egress-qos-del $*"
+        eip_egress_qos_del "$@"
         ;;
     qos-add)
-        echo "qos-add $rules"
-        qos_add $rules
+        echo "qos-add $*"
+        qos_add "$@"
         ;;
     qos-del)
-        echo "qos-del $rules"
-        qos_del $rules
+        echo "qos-del $*"
+        qos_del "$@"
         ;;
     *)
         echo "Unknown command: $opt"

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -72,6 +72,8 @@ function show_help() {
     echo "  floating-ip-del          - Delete floating IP mapping"
     echo "  dnat-add                 - Add DNAT rule"
     echo "  dnat-del                 - Delete DNAT rule"
+    echo "  nft-dnat-map-add         - Add nft map-based DNAT rule (Share type)"
+    echo "  nft-dnat-map-del         - Delete nft map-based DNAT rule (Share type)"
     echo "  snat-add                 - Add SNAT rule"
     echo "  snat-del                 - Delete SNAT rule"
     echo "  qos-add                  - Add QoS rule"
@@ -490,6 +492,155 @@ function del_dnat() {
           exec_cmd "$iptables_cmd -t nat -D $existingRule"
           conntrack -D -d "$eip" -p "$protocol" --dport "$dport" 2>/dev/null || true
         fi
+    done
+}
+
+# ===== nftables share DNAT (follows kube-proxy nftables pattern) =====
+#
+# Architecture (two-layer dispatch, same as kube-proxy):
+#   Table: kube-ovn
+#   ├── Base chain: prerouting (type nat hook prerouting priority -150)
+#   │   └── Rule: ip daddr . meta l4proto . th dport vmap @service-ips
+#   ├── Named vmap: service-ips
+#   │   └── Elements: { eip . protocol . port : goto dnat-XXXXX }  (element-level add/delete)
+#   └── Per-identity chains: dnat-XXXXX (one per eip:port:protocol)
+#       └── Rule: numgen random mod N dnat to ip addr . port map { backends }
+#
+# Atomicity: all operations use `nft -f` (single netlink batch transaction).
+# When backends change, only the per-identity chain is flushed + rebuilt.
+# The vmap element is stable (only added/removed when an identity is created/destroyed).
+#
+# Naming conventions:
+#   Shell variables: UPPER_CASE
+#   nft object names: lower_case (Linux/nftables convention, case-sensitive)
+
+NFT_TABLE="kube-ovn"
+NFT_SERVICES_MAP="service-ips"
+NFT_PREROUTING_CHAIN="prerouting"
+
+# Generate a per-identity chain name from eip:port:protocol.
+# Uses md5 hash prefix for uniqueness (same idea as kube-proxy's hashAndTruncate).
+function nft_identity_chain_name() {
+    local eip=$1 dport=$2 protocol=$3
+    local hash
+    hash=$(echo -n "${eip}:${dport}:${protocol}" | md5sum | cut -c1-8)
+    echo "dnat-${hash}"
+}
+
+# Execute an atomic nft transaction. All arguments are nft commands (one per arg).
+# Submitted as a single netlink batch via `nft -f`.
+# Returns 0 on success, non-zero on failure.
+function nft_transaction() {
+    printf '%s\n' "$@" | nft -f -
+}
+
+# Same as nft_transaction but ignores errors (for idempotent cleanup).
+function nft_transaction_ignore_errors() {
+    printf '%s\n' "$@" | nft -f - 2>/dev/null || true
+}
+
+function add_nft_dnat_map() {
+    # Add or update share-type DNAT backends for a given identity.
+    # Uses atomic nft transaction: ensure infrastructure + flush per-identity chain + re-add rule.
+    # All nft add operations are idempotent (no-op if already exists).
+    # Format: eip,dport,protocol,ip1:port1;ip2:port2;ip3:port3
+    check_inited
+    for rule in "$@"
+    do
+        IFS=',' read -r eip dport protocol backends <<< "$rule"
+
+        if [ -z "$eip" ] || [ -z "$dport" ] || [ -z "$protocol" ] || [ -z "$backends" ]; then
+            echo "Error: invalid nft-dnat-map rule: $rule"
+            exit 1
+        fi
+
+        # Parse backends and count them
+        IFS=';' read -ra backend_list <<< "$backends"
+        local count=${#backend_list[@]}
+
+        if [ "$count" -eq 0 ]; then
+            echo "Error: no backends specified in rule: $rule"
+            exit 1
+        fi
+
+        # Determine per-identity chain name
+        local identity_chain
+        identity_chain=$(nft_identity_chain_name "$eip" "$dport" "$protocol")
+
+        # Build numgen random mod N map entries (following kube-proxy pattern)
+        local map_entries=""
+        for i in "${!backend_list[@]}"; do
+            IFS=':' read -r ip port <<< "${backend_list[$i]}"
+            if [ -n "$map_entries" ]; then
+                map_entries="$map_entries, "
+            fi
+            map_entries="$map_entries$i : $ip . $port"
+        done
+
+        # Map protocol name to nft inet_proto keyword
+        local nft_proto
+        nft_proto=$(echo "$protocol" | tr '[:upper:]' '[:lower:]')
+
+        # Atomic transaction:
+        # 1. Ensure table, base chain, vmap exist (idempotent)
+        # 2. Flush + re-add dispatch rule in base chain
+        # 3. Flush per-identity chain + add new dnat rule
+        # 4. Ensure vmap element points to this chain
+        if ! nft_transaction \
+            "add table ip $NFT_TABLE" \
+            "add chain ip $NFT_TABLE $NFT_PREROUTING_CHAIN { type nat hook prerouting priority -150 ; }" \
+            "add map ip $NFT_TABLE $NFT_SERVICES_MAP { type ipv4_addr . inet_proto . inet_service : verdict ; }" \
+            "flush chain ip $NFT_TABLE $NFT_PREROUTING_CHAIN" \
+            "add rule ip $NFT_TABLE $NFT_PREROUTING_CHAIN ip daddr . meta l4proto . th dport vmap @$NFT_SERVICES_MAP" \
+            "add chain ip $NFT_TABLE $identity_chain" \
+            "flush chain ip $NFT_TABLE $identity_chain" \
+            "add rule ip $NFT_TABLE $identity_chain meta l4proto $nft_proto dnat ip addr . port to numgen random mod $count map { $map_entries }" \
+            "add element ip $NFT_TABLE $NFT_SERVICES_MAP { $eip . $nft_proto . $dport : goto $identity_chain }"
+        then
+            echo "Error: failed to update nft share dnat for $eip:$dport ($protocol)"
+            exit 1
+        fi
+
+        echo "Updated nft share dnat: $eip:$dport ($protocol) -> $backends (chain=$identity_chain)"
+    done
+}
+
+function del_nft_dnat_map() {
+    # Delete a share-type DNAT identity entirely.
+    # Removes vmap element + flushes and deletes per-identity chain.
+    # Format: eip,dport,protocol
+    for rule in "$@"
+    do
+        IFS=',' read -r eip dport protocol <<< "$rule"
+
+        if [ -z "$eip" ] || [ -z "$dport" ] || [ -z "$protocol" ]; then
+            echo "Error: invalid nft-dnat-map identity: $rule"
+            exit 1
+        fi
+
+        # Check if table exists
+        if ! nft list table ip $NFT_TABLE >/dev/null 2>&1; then
+            echo "NFT table $NFT_TABLE does not exist, nothing to delete"
+            return 0
+        fi
+
+        local identity_chain nft_proto
+        identity_chain=$(nft_identity_chain_name "$eip" "$dport" "$protocol")
+        nft_proto=$(echo "$protocol" | tr '[:upper:]' '[:lower:]')
+
+        # Delete vmap element and per-identity chain.
+        # These are separate operations because nft -f is transactional (all-or-nothing):
+        # if the element doesn't exist, a single transaction would roll back and
+        # leave the chain behind. By splitting, each step is independently idempotent.
+        nft delete element ip $NFT_TABLE $NFT_SERVICES_MAP "{ $eip . $nft_proto . $dport }" 2>/dev/null || true
+        nft_transaction_ignore_errors \
+            "flush chain ip $NFT_TABLE $identity_chain" \
+            "delete chain ip $NFT_TABLE $identity_chain"
+
+        # Clean up conntrack entries for this identity
+        conntrack -D -d "$eip" -p "$protocol" --dport "$dport" 2>/dev/null || true
+
+        echo "Deleted nft share dnat: $eip:$dport ($protocol) (chain=$identity_chain)"
     done
 }
 
@@ -1535,6 +1686,14 @@ case $opt in
     dnat-del)
         echo "dnat-del $rules"
         del_dnat $rules
+        ;;
+    nft-dnat-map-add)
+        echo "nft-dnat-map-add $*"
+        add_nft_dnat_map "$@"
+        ;;
+    nft-dnat-map-del)
+        echo "nft-dnat-map-del $*"
+        del_nft_dnat_map "$@"
         ;;
     snat-add)
         echo "snat-add $rules"

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -543,7 +543,9 @@ function add_nft_dnat_map() {
     # Add or update share-type DNAT backends for a given identity.
     # Uses atomic nft transaction: ensure infrastructure + flush per-identity chain + re-add rule.
     # All nft add operations are idempotent (no-op if already exists).
-    # Format: eip,dport,protocol,ip1:port1;ip2:port2;ip3:port3
+    # Format: eip,dport,protocol,ip1:port1@ip2:port2@ip3:port3
+    # Backends are '@'-separated (not ';') because the rule is passed as a single argument
+    # through pod-exec into a shell context, where ';' would act as a command separator.
     check_inited
     for rule in "$@"
     do

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -556,6 +556,22 @@ function add_nft_dnat_map() {
             exit 1
         fi
 
+        # Defense-in-depth format validation: the controller and webhook already validate
+        # these fields, but the shell must not blindly interpolate values into the nft
+        # transaction if an upstream check is ever bypassed (manual call / future call site).
+        if ! [[ "$eip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+            echo "Error: invalid eip in nft-dnat-map rule: $eip"
+            exit 1
+        fi
+        if ! [[ "$dport" =~ ^[0-9]+$ ]] || [ "$dport" -lt 1 ] || [ "$dport" -gt 65535 ]; then
+            echo "Error: invalid external port in nft-dnat-map rule: $dport"
+            exit 1
+        fi
+        if [ "$protocol" != "tcp" ] && [ "$protocol" != "udp" ] && [ "$protocol" != "TCP" ] && [ "$protocol" != "UDP" ]; then
+            echo "Error: invalid protocol in nft-dnat-map rule: $protocol"
+            exit 1
+        fi
+
         # Parse backends and count them
         IFS='@' read -ra backend_list <<< "$backends"
         local count=${#backend_list[@]}
@@ -573,6 +589,14 @@ function add_nft_dnat_map() {
         local map_entries=""
         for i in "${!backend_list[@]}"; do
             IFS=':' read -r ip port <<< "${backend_list[$i]}"
+            if ! [[ "$ip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+                echo "Error: invalid backend ip in nft-dnat-map rule: $ip"
+                exit 1
+            fi
+            if ! [[ "$port" =~ ^[0-9]+$ ]] || [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+                echo "Error: invalid backend port in nft-dnat-map rule: $port"
+                exit 1
+            fi
             if [ -n "$map_entries" ]; then
                 map_entries="$map_entries, "
             fi

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -520,6 +520,10 @@ NFT_PREROUTING_CHAIN="prerouting"
 
 # Generate a per-identity chain name from eip:port:protocol.
 # Uses md5 hash prefix for uniqueness (same idea as kube-proxy's hashAndTruncate).
+# Tradeoff: only the first 8 hex chars (32 bits) of the md5 are used. Collision probability
+# is negligible for the number of identities on a single gateway; a collision would make two
+# identities share (and mutually flush) the same per-identity chain. Widen the prefix if the
+# per-gateway identity count ever grows large enough for this to matter.
 function nft_identity_chain_name() {
     local eip=$1 dport=$2 protocol=$3
     local hash
@@ -654,6 +658,22 @@ function del_nft_dnat_map() {
             exit 1
         fi
 
+        # Defense-in-depth format validation, matching add_nft_dnat_map: the shell must not
+        # blindly interpolate values into nft delete element / conntrack if an upstream check
+        # is ever bypassed (manual call / future call site).
+        if ! [[ "$eip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+            echo "Error: invalid eip in nft-dnat-map identity: $eip"
+            exit 1
+        fi
+        if ! [[ "$dport" =~ ^[0-9]+$ ]] || [ "$dport" -lt 1 ] || [ "$dport" -gt 65535 ]; then
+            echo "Error: invalid external port in nft-dnat-map identity: $dport"
+            exit 1
+        fi
+        if [ "$protocol" != "tcp" ] && [ "$protocol" != "udp" ] && [ "$protocol" != "TCP" ] && [ "$protocol" != "UDP" ]; then
+            echo "Error: invalid protocol in nft-dnat-map identity: $protocol"
+            exit 1
+        fi
+
         local identity_chain nft_proto
         identity_chain=$(nft_identity_chain_name "$eip" "$dport" "$protocol")
         nft_proto=$(echo "$protocol" | tr '[:upper:]' '[:lower:]')
@@ -668,7 +688,7 @@ function del_nft_dnat_map() {
             "delete chain ip $NFT_TABLE $identity_chain"
 
         # Clean up conntrack entries for this identity
-        conntrack -D -d "$eip" -p "$protocol" --dport "$dport" 2>/dev/null || true
+        conntrack -D -d "$eip" -p "$nft_proto" --dport "$dport" 2>/dev/null || true
 
         echo "Deleted nft share dnat: $eip:$dport ($protocol) (chain=$identity_chain)"
     done

--- a/dist/images/vpcnatgateway/nat-gateway.sh
+++ b/dist/images/vpcnatgateway/nat-gateway.sh
@@ -524,14 +524,14 @@ NFT_PREROUTING_CHAIN="prerouting"
 
 # Generate a per-identity chain name from eip:port:protocol.
 # Uses md5 hash prefix for uniqueness (same idea as kube-proxy's hashAndTruncate).
-# Tradeoff: only the first 8 hex chars (32 bits) of the md5 are used. Collision probability
+# Tradeoff: only the first 12 hex chars (48 bits) of the md5 are used. Collision probability
 # is negligible for the number of identities on a single gateway; a collision would make two
 # identities share (and mutually flush) the same per-identity chain. Widen the prefix if the
 # per-gateway identity count ever grows large enough for this to matter.
 function nft_identity_chain_name() {
     local eip=$1 dport=$2 protocol=$3
     local hash
-    hash=$(echo -n "${eip}:${dport}:${protocol}" | md5sum | cut -c1-8)
+    hash=$(echo -n "${eip}:${dport}:${protocol}" | md5sum | cut -c1-12)
     echo "dnat-${hash}"
 }
 

--- a/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
+++ b/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
@@ -20,6 +20,18 @@ type IptablesDnatRuleList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
 // +resourceName=iptables-dnat-rules
+// +kubebuilder:resource:scope="Cluster",shortName="dnat",path="iptables-dnat-rules",singular="iptables-dnat-rule"
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Eip",type="string",JSONPath=".spec.eip"
+// +kubebuilder:printcolumn:name="Protocol",type="string",JSONPath=".spec.protocol"
+// +kubebuilder:printcolumn:name="V4ip",type="string",JSONPath=".status.v4ip"
+// +kubebuilder:printcolumn:name="V6ip",type="string",JSONPath=".status.v6ip"
+// +kubebuilder:printcolumn:name="InternalIp",type="string",JSONPath=".spec.internalIp"
+// +kubebuilder:printcolumn:name="ExternalPort",type="string",JSONPath=".spec.externalPort"
+// +kubebuilder:printcolumn:name="InternalPort",type="string",JSONPath=".spec.internalPort"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
+// +kubebuilder:printcolumn:name="NatGwDp",type="string",JSONPath=".status.natGwDp"
+// +kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.ready"
 type IptablesDnatRule struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -28,12 +40,38 @@ type IptablesDnatRule struct {
 	Status IptablesDnatRuleStatus `json:"status"`
 }
 
+const (
+	// DnatRuleTypeExclusive means the EIP:Port is exclusively used by this DNAT rule.
+	// Only one internal IP:Port can be mapped to a given EIP:Port identity (eip + externalPort + protocol).
+	// This is the original (default) behavior: uses a single iptables DNAT rule for 1:1 port forwarding.
+	// Creating another DNAT rule with the same identity is rejected.
+	DnatRuleTypeExclusive = "exclusive"
+
+	// DnatRuleTypeShare means multiple DNAT rules can share the same EIP:Port.
+	// Different internal IP:Port backends are allowed to coexist under the same identity,
+	// enabling load-balancing across backends. Implemented via nftables jhash map-based DNAT
+	// (distributes traffic by hashing src IP + src port), introduced to support nft LB scenarios.
+	DnatRuleTypeShare = "share"
+)
+
 type IptablesDnatRuleSpec struct {
 	EIP          string `json:"eip"`
 	ExternalPort string `json:"externalPort"`
 	Protocol     string `json:"protocol,omitempty"`
 	InternalIP   string `json:"internalIp"`
 	InternalPort string `json:"internalPort"`
+	// Type of the DNAT rule, controls whether the EIP:Port identity can be shared
+	// by multiple internal backends:
+	// - "exclusive" (default): The EIP:Port is exclusively owned by this single DNAT rule.
+	//   Uses iptables DNAT for 1:1 port forwarding. This was the only mode before the
+	//   nft LB feature was introduced; any duplicate identity is rejected.
+	// - "share": Multiple DNAT rules may share the same EIP:Port identity, each
+	//   contributing a different internal IP:Port as a backend. Traffic is distributed
+	//   across backends using nftables jhash map-based DNAT (hash of src IP + src port).
+	// +kubebuilder:validation:Enum=exclusive;share
+	// +kubebuilder:default=exclusive
+	// +optional
+	Type string `json:"type,omitempty"`
 }
 
 type IptablesDnatRuleStatus struct {

--- a/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
+++ b/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
@@ -52,6 +52,9 @@ const (
 	// enabling load-balancing across backends. Implemented via nftables numgen random
 	// map-based DNAT: new connections are distributed randomly across backends and then
 	// pinned by conntrack (connection-level balancing, no client-IP affinity).
+	// IPv4 only: the nft rules use `ip daddr`/`ip saddr`, so share requires an EIP with an
+	// IPv4 address; the webhook rejects share on an IPv6-only EIP and the controller requeues
+	// while the EIP is still being allocated (v4 not yet assigned).
 	DnatRuleTypeShare = "share"
 )
 

--- a/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
+++ b/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
@@ -49,8 +49,9 @@ const (
 
 	// DnatRuleTypeShare means multiple DNAT rules can share the same EIP:Port.
 	// Different internal IP:Port backends are allowed to coexist under the same identity,
-	// enabling load-balancing across backends. Implemented via nftables jhash map-based DNAT
-	// (distributes traffic by hashing src IP + src port), introduced to support nft LB scenarios.
+	// enabling load-balancing across backends. Implemented via nftables numgen random
+	// map-based DNAT: new connections are distributed randomly across backends and then
+	// pinned by conntrack (connection-level balancing, no client-IP affinity).
 	DnatRuleTypeShare = "share"
 )
 
@@ -67,7 +68,9 @@ type IptablesDnatRuleSpec struct {
 	//   nft LB feature was introduced; any duplicate identity is rejected.
 	// - "share": Multiple DNAT rules may share the same EIP:Port identity, each
 	//   contributing a different internal IP:Port as a backend. Traffic is distributed
-	//   across backends using nftables jhash map-based DNAT (hash of src IP + src port).
+	//   across backends using nftables numgen random map-based DNAT: each new connection
+	//   picks a backend at random and is then pinned by conntrack (connection-level
+	//   balancing, no client-IP affinity).
 	// +kubebuilder:validation:Enum=exclusive;share
 	// +kubebuilder:default=exclusive
 	// +optional

--- a/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
+++ b/pkg/apis/kubeovn/v1/iptables-dnat-rule.go
@@ -59,10 +59,15 @@ const (
 )
 
 type IptablesDnatRuleSpec struct {
-	EIP          string `json:"eip"`
+	// EIP name for DNAT rule
+	EIP string `json:"eip"`
+	// External port number
 	ExternalPort string `json:"externalPort"`
-	Protocol     string `json:"protocol,omitempty"`
-	InternalIP   string `json:"internalIp"`
+	// Protocol type (TCP or UDP)
+	Protocol string `json:"protocol,omitempty"`
+	// Internal IP address to forward traffic to
+	InternalIP string `json:"internalIp"`
+	// Internal port number to forward traffic to
 	InternalPort string `json:"internalPort"`
 	// Type of the DNAT rule, controls whether the EIP:Port identity can be shared
 	// by multiple internal backends:
@@ -81,16 +86,25 @@ type IptablesDnatRuleSpec struct {
 }
 
 type IptablesDnatRuleStatus struct {
+	// Indicates whether the DNAT rule is ready
 	// +optional
 	// +patchStrategy=merge
-	Ready        bool   `json:"ready" patchStrategy:"merge"`
-	V4ip         string `json:"v4ip" patchStrategy:"merge"`
-	V6ip         string `json:"v6ip" patchStrategy:"merge"`
-	NatGwDp      string `json:"natGwDp" patchStrategy:"merge"`
-	Redo         string `json:"redo" patchStrategy:"merge"`
-	Protocol     string `json:"protocol"  patchStrategy:"merge"`
-	InternalIP   string `json:"internalIp"  patchStrategy:"merge"`
+	Ready bool `json:"ready" patchStrategy:"merge"`
+	// V4ip is the IPv4 address of the DNAT rule
+	V4ip string `json:"v4ip" patchStrategy:"merge"`
+	// V6ip is the IPv6 address of the DNAT rule
+	V6ip string `json:"v6ip" patchStrategy:"merge"`
+	// NatGwDp is the NAT gateway data path
+	NatGwDp string `json:"natGwDp" patchStrategy:"merge"`
+	// Redo operation status
+	Redo string `json:"redo" patchStrategy:"merge"`
+	// Protocol type of the DNAT rule
+	Protocol string `json:"protocol"  patchStrategy:"merge"`
+	// Internal IP address configured in the DNAT rule
+	InternalIP string `json:"internalIp"  patchStrategy:"merge"`
+	// Internal port configured in the DNAT rule
 	InternalPort string `json:"internalPort"  patchStrategy:"merge"`
+	// External port configured in the DNAT rule
 	ExternalPort string `json:"externalPort"  patchStrategy:"merge"`
 
 	// Conditions represents the latest state of the object

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -1,0 +1,251 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+)
+
+// nft share DNAT architecture (follows kube-proxy nftables pattern):
+//
+//   Table: kube-ovn
+//   ├── Base chain: prerouting (type nat hook prerouting priority -150)
+//   │   └── Rule: ip daddr . meta l4proto . th dport vmap @service-ips
+//   ├── Named vmap: service-ips
+//   │   └── Elements: { eip . protocol . port : goto dnat-XXXXX }  (element-level add/delete)
+//   └── Per-identity chains: dnat-XXXXX
+//       └── Rule: numgen random mod N map { 0 : ip1 . port1, 1 : ip2 . port2, ... }
+//
+// Operations:
+//   - Add/remove backend: flush per-identity chain + re-add rule (atomic batch via nft -f)
+//   - Add new identity: create chain + add rule + add vmap element
+//   - Remove identity: delete vmap element + flush & delete chain
+//
+// Naming conventions:
+//   - Shell variables: UPPER_CASE (NFT_TABLE, NFT_SERVICES_MAP, ...)
+//   - nft object names: lower_case with hyphens/underscores (Linux/nftables convention)
+//   - Per-identity chain: "dnat-" + md5(eip:port:protocol)[:8]  (generated in shell)
+
+const (
+	// natGwNftDnatMapAdd is the shell command for adding/updating a share DNAT identity.
+	natGwNftDnatMapAdd = "nft-dnat-map-add"
+
+	// natGwNftDnatMapDel is the shell command for deleting a share DNAT identity.
+	natGwNftDnatMapDel = "nft-dnat-map-del"
+)
+
+// createNftDnatMapInPod creates or updates an nftables map-based DNAT rule for Share type.
+// This is the core function for the nft LB feature: it builds an nft transaction that
+// atomically updates the per-identity chain with the full set of backends.
+//
+// The transaction (submitted via nft -f) contains:
+//  1. Ensure table, base chain, and vmap exist
+//  2. Flush the per-identity chain (remove old rule)
+//  3. Add new rule with numgen random mod N map { all backends }
+//  4. Ensure vmap element dispatches to this chain
+//
+// The backends format passed to the gateway script is "ip1:port1;ip2:port2;...".
+func (c *Controller) createNftDnatMapInPod(dp, protocol, v4ip, externalPort string, backends []string) error {
+	if v4ip == "" {
+		// Share DNAT is implemented with `ip daddr`/`ip saddr` nft rules and only supports IPv4.
+		return errors.New("cannot create nft dnat map: empty IPv4 EIP (share dnat does not support IPv6)")
+	}
+	// Normalize the backend set: dedup and sort so that an unchanged set of backends always
+	// produces an identical nft map. Without this, the lister's non-deterministic order would
+	// reshuffle the map keys on every rebuild/redo and gratuitously rehash live connections.
+	backends = dedupSortedBackends(backends)
+	if len(backends) == 0 {
+		return fmt.Errorf("cannot create nft dnat map for %s:%s (%s): no backends", v4ip, externalPort, protocol)
+	}
+
+	gwPod, err := c.getNatGwPod(dp, c.natGwNamespaceByName(dp))
+	if err != nil {
+		klog.Errorf("failed to get nat gw pod, %v", err)
+		return err
+	}
+
+	backendStr := strings.Join(backends, ";")
+	rule := fmt.Sprintf("%s,%s,%s,%s", v4ip, externalPort, protocol, backendStr)
+	if err = c.execNatGwRules(gwPod, natGwNftDnatMapAdd, []string{rule}); err != nil {
+		klog.Errorf("failed to create nft dnat map, err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// deleteNftDnatMapInPod deletes an nftables map-based DNAT rule by identity.
+// It removes the vmap element and the per-identity chain atomically.
+func (c *Controller) deleteNftDnatMapInPod(dp, protocol, v4ip, externalPort string) error {
+	deleted, err := c.natGwDeleted(dp)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	if deleted {
+		return nil
+	}
+	gwPod, err := c.getNatGwPod(dp, c.natGwNamespaceByName(dp))
+	if err != nil {
+		klog.Errorf("failed to get nat gw pod, %v", err)
+		return err
+	}
+
+	rule := fmt.Sprintf("%s,%s,%s", v4ip, externalPort, protocol)
+	if err = c.execNatGwRules(gwPod, natGwNftDnatMapDel, []string{rule}); err != nil {
+		klog.Errorf("failed to delete nft dnat map, err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// dedupSortedBackends returns the unique backends in sorted order, dropping empty entries.
+func dedupSortedBackends(backends []string) []string {
+	if len(backends) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(backends))
+	uniq := make([]string, 0, len(backends))
+	for _, b := range backends {
+		if b == "" {
+			continue
+		}
+		if _, ok := seen[b]; ok {
+			continue
+		}
+		seen[b] = struct{}{}
+		uniq = append(uniq, b)
+	}
+	if len(uniq) == 0 {
+		return nil
+	}
+	sort.Strings(uniq)
+	return uniq
+}
+
+// getShareBackends queries all Share-type DNAT rules with the same identity (eip, externalPort, protocol)
+// and returns their backends. The current DNAT (identified by dnatName) is excluded from the results.
+//
+// Backends are derived from each sibling's Spec (not Status) on purpose: the nft map for a given
+// identity is global and is rebuilt in full by whichever sibling reconciles last. Relying on
+// Status.Ready would create a race across the add/update/delete queues, where a sibling that is
+// momentarily not-yet-Ready gets excluded and silently dropped from the map by the last writer.
+// A sibling's Spec backend is populated as soon as it exists, so using it makes the rebuild
+// order-independent. Siblings that are being deleted are skipped so their backend is not re-added.
+func (c *Controller) getShareBackends(gwName, eipName, externalPort, protocol, dnatName string) ([]string, error) {
+	// The label selector only coarse-filters by gateway name + external port; the EIP
+	// identity is intentionally enforced as a Spec post-filter below (d.Spec.EIP != eipName)
+	// rather than added to the selector:
+	//   - EIP name cannot be a label value: IptablesEIP is a cluster-scoped CR whose name may be
+	//     up to 253 chars, exceeding the 63-char Kubernetes label-value limit, which would make
+	//     patchDnatLabel fail and stall reconcile. The authoritative identity is therefore matched
+	//     by name in the Spec post-filter, which has no length limit.
+	//   - EIP IP (EipV4IpLabel) could technically be added to the selector, but it gives no real
+	//     benefit. The informer registers only a namespace indexer (no label index), so
+	//     lister.List(selector) always does cache.ListAll: a full O(all-DNATs) scan that applies
+	//     selector.Matches per object. Adding EipV4IpLabel does not shrink that scan; it only moves
+	//     the EIP comparison from the post-filter loop into the per-object selector match during the
+	//     same full scan, so total work is unchanged (arguably a hair more). It would also couple
+	//     every call site (including the redo path, which only has cachedDnat.Status.V4ip and no eip
+	//     object) to the Spec.V4ip == Status.IP backfill invariant. We keep EIP as a single-source
+	//     Spec post-filter. A genuine speedup would require a dedicated label indexer, which is
+	//     over-engineering for this small per-(gw,eport) set.
+	// gwName + externalPort are safe selector dimensions: both are always populated, immutable
+	// (NatGwDp is webhook-immutable, externalPort comes straight from the DNAT Spec), and short.
+	// gwName is explicitly length-validated by the VpcNatGateway webhook via
+	// ValidateNatGwStatefulSetNameLength (<=52 chars, derived from the 63-char label-value limit
+	// minus the StatefulSet revision-hash suffix), so it always fits in a label value; IptablesEIP
+	// has no such name-length webhook, which is the real reason its name cannot be used as a label.
+	dnats, err := c.iptablesDnatRulesLister.List(labels.SelectorFromSet(labels.Set{
+		util.VpcNatGatewayNameLabel: gwName,
+		util.VpcDnatEPortLabel:      externalPort,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	var backends []string
+	for _, d := range dnats {
+		if d.Name == dnatName {
+			continue
+		}
+		if d.Spec.EIP != eipName || d.Spec.Protocol != protocol || d.Spec.ExternalPort != externalPort {
+			continue
+		}
+		if d.Spec.Type != kubeovnv1.DnatRuleTypeShare {
+			continue
+		}
+		if !d.DeletionTimestamp.IsZero() {
+			klog.V(4).Infof("skipping share dnat %s: being deleted", d.Name)
+			continue
+		}
+		if d.Spec.InternalIP == "" || d.Spec.InternalPort == "" {
+			klog.V(4).Infof("skipping share dnat %s: incomplete spec", d.Name)
+			continue
+		}
+		backends = append(backends, fmt.Sprintf("%s:%s", d.Spec.InternalIP, d.Spec.InternalPort))
+	}
+	return backends, nil
+}
+
+// cleanupShareDnatInPod rebuilds the share nft map with the remaining backends for the given
+// identity, or deletes the rule entirely when no backend is left after excluding dnatName.
+func (c *Controller) cleanupShareDnatInPod(key, gwName, eipName, protocol, v4ip, externalPort, dnatName string) error {
+	remainingBackends, err := c.getShareBackends(gwName, eipName, externalPort, protocol, dnatName)
+	if err != nil {
+		return fmt.Errorf("failed to get share backends for dnat %s: %w", key, err)
+	}
+	if len(remainingBackends) == 0 {
+		// No remaining backends, delete the nft rule
+		if err := c.deleteNftDnatMapInPod(gwName, protocol, v4ip, externalPort); err != nil {
+			return fmt.Errorf("failed to delete nft dnat map for %s: %w", key, err)
+		}
+		return nil
+	}
+	// Rebuild nft rule with remaining backends
+	if err := c.createNftDnatMapInPod(gwName, protocol, v4ip, externalPort, remainingBackends); err != nil {
+		return fmt.Errorf("failed to rebuild nft dnat map for %s: %w", key, err)
+	}
+	return nil
+}
+
+// isDnatDuplicated checks if a DNAT rule with the same identity already exists.
+// For Share type rules, multiple rules with the same identity can coexist.
+// For Exclusive type, only one rule per identity is allowed.
+func (c *Controller) isDnatDuplicated(gwName, eipName, dnatName, externalPort, protocol, dnatType string) (bool, error) {
+	// Check if the tuple "eip:external port:protocol" is already used by another DNAT rule.
+	// EIP identity is enforced via the Spec post-filter (d.Spec.EIP != eipName) below rather
+	// than in the selector; see getShareBackends for why EIP name/IP cannot be used as labels.
+	dnats, err := c.iptablesDnatRulesLister.List(labels.SelectorFromSet(labels.Set{
+		util.VpcNatGatewayNameLabel: gwName,
+		util.VpcDnatEPortLabel:      externalPort,
+	}))
+	if err != nil {
+		return false, err
+	}
+	if len(dnats) == 0 {
+		return false, nil
+	}
+
+	for _, d := range dnats {
+		if d.Name == dnatName || d.Spec.EIP != eipName || d.Spec.Protocol != protocol {
+			continue
+		}
+		// Found a DNAT with same identity
+		if dnatType == kubeovnv1.DnatRuleTypeShare && d.Spec.Type == kubeovnv1.DnatRuleTypeShare {
+			// Both are Share type, allow coexistence
+			continue
+		}
+		// Type conflict: Exclusive vs Share, or Exclusive vs Exclusive
+		err = fmt.Errorf("failed to create dnat %s, duplicate, same eip %s, same external port '%s', same protocol '%s' is used by dnat %s (type=%s)",
+			dnatName, eipName, externalPort, protocol, d.Name, d.Spec.Type)
+		return true, err
+	}
+	return false, nil
+}

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -28,6 +28,18 @@ import (
 //   - Add new identity: create chain + add rule + add vmap element
 //   - Remove identity: delete vmap element + flush & delete chain
 //
+// Coexistence with exclusive (iptables) DNAT:
+//   Two DNAT paths run in the same gateway pod. Exclusive-type rules use iptables
+//   nat/PREROUTING (priority NF_IP_PRI_NAT_DST, ~ -100), while share-type rules use this nft
+//   base chain at priority -150, so the nft hook runs first. This is not a functional conflict
+//   because the webhook enforces that a given identity (eip + externalPort + protocol) is
+//   mutually exclusive across types, and DNAT/FIP for the same EIP are also mutually exclusive;
+//   a packet is therefore only ever matched by one path. The ordering matters mainly for
+//   troubleshooting boundary cases, e.g. when a rule's type is switched after conntrack has
+//   already pinned a connection (existing flows keep their old destination until they expire).
+//   Recommendation: within a single gateway, prefer using one mode consistently (share/nft) so
+//   there is a single DNAT path to reason about and debug.
+//
 // Naming conventions:
 //   - Shell variables: UPPER_CASE (NFT_TABLE, NFT_SERVICES_MAP, ...)
 //   - nft object names: lower_case with hyphens/underscores (Linux/nftables convention)

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -32,6 +32,14 @@ import (
 //   - Shell variables: UPPER_CASE (NFT_TABLE, NFT_SERVICES_MAP, ...)
 //   - nft object names: lower_case with hyphens/underscores (Linux/nftables convention)
 //   - Per-identity chain: "dnat-" + md5(eip:port:protocol)[:8]  (generated in shell)
+//
+// TODO(share-dnat): source-IP session affinity is not supported yet. Backends are selected
+// purely at random (numgen random) and then pinned per-connection by conntrack; there is no
+// client-IP affinity. kube-proxy's nftables backend implements ClientIP affinity by recording
+// the source IP in a dynamic nftables set ("update @affinity-set { ip saddr }" in the per-endpoint
+// chain, plus a preceding "ip saddr @affinity-set goto <ep>" lookup), layered on top of the same
+// numgen random dispatch (not jhash). The same approach could be adopted here if per-client
+// affinity is needed in the future.
 
 const (
 	// natGwNftDnatMapAdd is the shell command for adding/updating a share DNAT identity.

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -51,7 +51,10 @@ const (
 //  3. Add new rule with numgen random mod N map { all backends }
 //  4. Ensure vmap element dispatches to this chain
 //
-// The backends format passed to the gateway script is "ip1:port1;ip2:port2;...".
+// The backends format passed to the gateway script is "ip1:port1@ip2:port2@...".
+// '@' is used as the separator (not ';') because the rule string is passed as a single
+// argument through the pod-exec API into a shell context, where ';' would be interpreted
+// as a command separator; '@' never appears in an ip:port and is shell-safe.
 func (c *Controller) createNftDnatMapInPod(dp, protocol, v4ip, externalPort string, backends []string) error {
 	if v4ip == "" {
 		// Share DNAT is implemented with `ip daddr`/`ip saddr` nft rules and only supports IPv4.
@@ -138,6 +141,12 @@ func dedupSortedBackends(backends []string) []string {
 // momentarily not-yet-Ready gets excluded and silently dropped from the map by the last writer.
 // A sibling's Spec backend is populated as soon as it exists, so using it makes the rebuild
 // order-independent. Siblings that are being deleted are skipped so their backend is not re-added.
+//
+// This relies on the informer cache being in sync: a sibling's Spec must already be visible in
+// the lister for its backend to be included. If a sibling was just created and its create event
+// has not yet propagated to this lister cache, the last writer will build a map that temporarily
+// omits that backend. This is not a bug: the missing sibling's own add/update event triggers a
+// later reconcile that rebuilds the full map, so the set self-heals to the complete backend list.
 func (c *Controller) getShareBackends(gwName, eipName, externalPort, protocol, dnatName string) ([]string, error) {
 	// The label selector only coarse-filters by gateway name + external port; the EIP
 	// identity is intentionally enforced as a Spec post-filter below (d.Spec.EIP != eipName)
@@ -196,6 +205,13 @@ func (c *Controller) getShareBackends(gwName, eipName, externalPort, protocol, d
 
 // cleanupShareDnatInPod rebuilds the share nft map with the remaining backends for the given
 // identity, or deletes the rule entirely when no backend is left after excluding dnatName.
+//
+// When a single backend is removed while the identity still has other backends, this rebuilds
+// the per-identity map in place without deleting the identity or flushing conntrack. Established
+// connections that were pinned to the removed backend may therefore be rehashed to a different
+// backend (or dropped) by the new numgen map. This is the expected behavior when detaching a
+// backend from a load balancer. Conntrack is only cleared on full identity deletion (see
+// deleteNftDnatMapInPod / del_nft_dnat_map in the gateway script).
 func (c *Controller) cleanupShareDnatInPod(key, gwName, eipName, protocol, v4ip, externalPort, dnatName string) error {
 	remainingBackends, err := c.getShareBackends(gwName, eipName, externalPort, protocol, dnatName)
 	if err != nil {

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -43,7 +43,7 @@ import (
 // Naming conventions:
 //   - Shell variables: UPPER_CASE (NFT_TABLE, NFT_SERVICES_MAP, ...)
 //   - nft object names: lower_case with hyphens/underscores (Linux/nftables convention)
-//   - Per-identity chain: "dnat-" + md5(eip:port:protocol)[:8]  (generated in shell)
+//   - Per-identity chain: "dnat-" + md5(eip:port:protocol)[:12]  (generated in shell)
 //
 // TODO(share-dnat): source-IP session affinity is not supported yet. Backends are selected
 // purely at random (numgen random) and then pinned per-connection by conntrack; there is no

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -62,7 +62,9 @@ func (c *Controller) createNftDnatMapInPod(dp, protocol, v4ip, externalPort stri
 	}
 	// Normalize the backend set: dedup and sort so that an unchanged set of backends always
 	// produces an identical nft map. Without this, the lister's non-deterministic order would
-	// reshuffle the map keys on every rebuild/redo and gratuitously rehash live connections.
+	// rewrite the numgen random map on every rebuild/redo even when nothing changed, causing
+	// gratuitous nft rule churn (and reshuffling index->backend, which only affects the random
+	// choice for new connections; established connections stay pinned by conntrack).
 	backends = dedupSortedBackends(backends)
 	if len(backends) == 0 {
 		return fmt.Errorf("cannot create nft dnat map for %s:%s (%s): no backends", v4ip, externalPort, protocol)
@@ -207,11 +209,13 @@ func (c *Controller) getShareBackends(gwName, eipName, externalPort, protocol, d
 // identity, or deletes the rule entirely when no backend is left after excluding dnatName.
 //
 // When a single backend is removed while the identity still has other backends, this rebuilds
-// the per-identity map in place without deleting the identity or flushing conntrack. Established
-// connections that were pinned to the removed backend may therefore be rehashed to a different
-// backend (or dropped) by the new numgen map. This is the expected behavior when detaching a
-// backend from a load balancer. Conntrack is only cleared on full identity deletion (see
-// deleteNftDnatMapInPod / del_nft_dnat_map in the gateway script).
+// the per-identity map in place without deleting the identity or flushing conntrack. Backends are
+// balanced with numgen random, so established connections are pinned by conntrack: connections to
+// surviving backends are unaffected, and connections to the removed backend are not flushed here
+// (they simply break once that backend is gone). New connections are distributed by the rebuilt
+// numgen random map. This is the expected behavior when detaching a backend from a load balancer.
+// Conntrack is only cleared on full identity deletion (see deleteNftDnatMapInPod /
+// del_nft_dnat_map in the gateway script).
 func (c *Controller) cleanupShareDnatInPod(key, gwName, eipName, protocol, v4ip, externalPort, dnatName string) error {
 	remainingBackends, err := c.getShareBackends(gwName, eipName, externalPort, protocol, dnatName)
 	if err != nil {

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -71,7 +71,7 @@ func (c *Controller) createNftDnatMapInPod(dp, protocol, v4ip, externalPort stri
 		return err
 	}
 
-	backendStr := strings.Join(backends, ";")
+	backendStr := strings.Join(backends, "@")
 	rule := fmt.Sprintf("%s,%s,%s,%s", v4ip, externalPort, protocol, backendStr)
 	if err = c.execNatGwRules(gwPod, natGwNftDnatMapAdd, []string{rule}); err != nil {
 		klog.Errorf("failed to create nft dnat map, err: %v", err)

--- a/pkg/controller/nft_dnat.go
+++ b/pkg/controller/nft_dnat.go
@@ -246,6 +246,16 @@ func (c *Controller) cleanupShareDnatInPod(key, gwName, eipName, protocol, v4ip,
 // isDnatDuplicated checks if a DNAT rule with the same identity already exists.
 // For Share type rules, multiple rules with the same identity can coexist.
 // For Exclusive type, only one rule per identity is allowed.
+//
+// Consistency note: this check (and the equivalent webhook check in ValidateIptablesDnat) reads
+// the informer lister / controller-runtime cache, which is only eventually consistent. If two
+// conflicting exclusive rules are created concurrently before either is visible in the cache,
+// both can pass this check and be admitted. This is a pre-existing limitation of the cache-based
+// duplicate detection, not specific to the share feature (the share feature only widens the set
+// of legitimately-coexisting objects under one identity). The reconcile loop is the eventual
+// authority: it re-runs this check on every sync, so a conflict that slipped through is detected
+// on a subsequent reconcile and the offending rule fails to become Ready (last-writer-wins /
+// eventual consistency). The webhook is best-effort admission-time protection, not a hard guarantee.
 func (c *Controller) isDnatDuplicated(gwName, eipName, dnatName, externalPort, protocol, dnatType string) (bool, error) {
 	// Check if the tuple "eip:external port:protocol" is already used by another DNAT rule.
 	// EIP identity is enforced via the Spec post-filter (d.Spec.EIP != eipName) below rather

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -656,6 +656,13 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 	}
 	klog.V(3).Infof("handle update dnat %s", key)
 
+	// add or update should make sure vpc nat enabled. Checked before validateDnatRule and the
+	// isDnatDuplicated lister scan (matching handleAddIptablesDnatRule) so we do not scan when
+	// the NAT GW is disabled.
+	if vpcNatEnabled != "true" {
+		return errors.New("iptables nat gw not enable")
+	}
+
 	if err := c.validateDnatRule(cachedDnat); err != nil {
 		return err
 	}
@@ -668,10 +675,6 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Name, cachedDnat.Spec.ExternalPort, cachedDnat.Spec.Protocol, cachedDnat.Spec.Type); dup || err != nil {
 		klog.Errorf("failed to update dnat, %v", err)
 		return err
-	}
-	// add or update should make sure vpc nat enabled
-	if vpcNatEnabled != "true" {
-		return errors.New("iptables nat gw not enable")
 	}
 
 	if eip.Spec.NatGwDp == "" {

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -549,7 +549,7 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
 	}
-	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, dnat.Spec.EIP, dnat.Name, dnat.Spec.ExternalPort, dnat.Spec.Protocol); dup || err != nil {
+	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, dnat.Spec.EIP, dnat.Name, dnat.Spec.ExternalPort, dnat.Spec.Protocol, dnat.Spec.Type); dup || err != nil {
 		klog.Error(err)
 		return err
 	}
@@ -560,11 +560,29 @@ func (c *Controller) handleAddIptablesDnatRule(key string) error {
 		klog.Errorf("failed to handle add finalizer for dnat, %v", err)
 		return err
 	}
-	if err = c.createDnatInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol,
-		eip.Status.IP, dnat.Spec.InternalIP,
-		dnat.Spec.ExternalPort, dnat.Spec.InternalPort); err != nil {
-		klog.Errorf("failed to create dnat, %v", err)
-		return err
+
+	switch dnat.Spec.Type {
+	case kubeovnv1.DnatRuleTypeShare:
+		// Share type: use nft map-based DNAT
+		backends, err := c.getShareBackends(eip.Spec.NatGwDp, dnat.Spec.EIP, dnat.Spec.ExternalPort, dnat.Spec.Protocol, dnat.Name)
+		if err != nil {
+			klog.Errorf("failed to get share backends for dnat %s: %v", key, err)
+			return err
+		}
+		// Add current DNAT's backend
+		backends = append(backends, fmt.Sprintf("%s:%s", dnat.Spec.InternalIP, dnat.Spec.InternalPort))
+		if err = c.createNftDnatMapInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol, eip.Status.IP, dnat.Spec.ExternalPort, backends); err != nil {
+			klog.Errorf("failed to create nft dnat map, %v", err)
+			return err
+		}
+	default:
+		// Exclusive type (default): use iptables DNAT
+		if err = c.createDnatInPod(eip.Spec.NatGwDp, dnat.Spec.Protocol,
+			eip.Status.IP, dnat.Spec.InternalIP,
+			dnat.Spec.ExternalPort, dnat.Spec.InternalPort); err != nil {
+			klog.Errorf("failed to create dnat, %v", err)
+			return err
+		}
 	}
 	if err = c.patchDnatStatus(key, eip.Status.IP, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 		klog.Errorf("failed to patch status for dnat %s, %v", key, err)
@@ -647,7 +665,7 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		klog.Errorf("failed to get eip, %v", err)
 		return err
 	}
-	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Name, cachedDnat.Spec.ExternalPort, cachedDnat.Spec.Protocol); dup || err != nil {
+	if dup, err := c.isDnatDuplicated(eip.Spec.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Name, cachedDnat.Spec.ExternalPort, cachedDnat.Spec.Protocol, cachedDnat.Spec.Type); dup || err != nil {
 		klog.Errorf("failed to update dnat, %v", err)
 		return err
 	}
@@ -713,11 +731,28 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 		if err = c.finalDeleteDnatInPod(key, cachedDnat); err != nil {
 			return err
 		}
-		if err = c.createDnatInPod(eip.Spec.NatGwDp, newProtocol,
-			newV4ip, newInternalIP,
-			newExternalPort, newInternalPort); err != nil {
-			klog.Errorf("failed to create dnat %s, %v", key, err)
-			return err
+
+		switch cachedDnat.Spec.Type {
+		case kubeovnv1.DnatRuleTypeShare:
+			// Share type: rebuild nft rule with updated backends
+			backends, err := c.getShareBackends(eip.Spec.NatGwDp, cachedDnat.Spec.EIP, newExternalPort, newProtocol, cachedDnat.Name)
+			if err != nil {
+				klog.Errorf("failed to get share backends for dnat %s: %v", key, err)
+				return err
+			}
+			backends = append(backends, fmt.Sprintf("%s:%s", newInternalIP, newInternalPort))
+			if err = c.createNftDnatMapInPod(eip.Spec.NatGwDp, newProtocol, newV4ip, newExternalPort, backends); err != nil {
+				klog.Errorf("failed to create nft dnat map for %s, %v", key, err)
+				return err
+			}
+		default:
+			// Exclusive type: use iptables DNAT
+			if err = c.createDnatInPod(eip.Spec.NatGwDp, newProtocol,
+				newV4ip, newInternalIP,
+				newExternalPort, newInternalPort); err != nil {
+				klog.Errorf("failed to create dnat %s, %v", key, err)
+				return err
+			}
 		}
 		if err = c.patchDnatStatus(key, newV4ip, eip.Spec.V6ip, eip.Spec.NatGwDp, "", true); err != nil {
 			klog.Errorf("failed to patch status for dnat %s, %v", key, err)
@@ -766,11 +801,28 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 			klog.V(3).Infof("dnat %s: pod started before redo mark, rules intact, skip", key)
 			return nil
 		}
-		if err = c.createDnatInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol,
-			cachedDnat.Status.V4ip, cachedDnat.Status.InternalIP,
-			cachedDnat.Status.ExternalPort, cachedDnat.Status.InternalPort); err != nil {
-			klog.Errorf("failed to create dnat %s, %v", key, err)
-			return err
+
+		switch cachedDnat.Spec.Type {
+		case kubeovnv1.DnatRuleTypeShare:
+			// Share type: rebuild nft rule with all backends
+			backends, err := c.getShareBackends(cachedDnat.Status.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Status.ExternalPort, cachedDnat.Status.Protocol, cachedDnat.Name)
+			if err != nil {
+				klog.Errorf("failed to get share backends for dnat %s: %v", key, err)
+				return err
+			}
+			backends = append(backends, fmt.Sprintf("%s:%s", cachedDnat.Status.InternalIP, cachedDnat.Status.InternalPort))
+			if err = c.createNftDnatMapInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol, cachedDnat.Status.V4ip, cachedDnat.Status.ExternalPort, backends); err != nil {
+				klog.Errorf("failed to create nft dnat map for %s, %v", key, err)
+				return err
+			}
+		default:
+			// Exclusive type: use iptables DNAT
+			if err = c.createDnatInPod(cachedDnat.Status.NatGwDp, cachedDnat.Status.Protocol,
+				cachedDnat.Status.V4ip, cachedDnat.Status.InternalIP,
+				cachedDnat.Status.ExternalPort, cachedDnat.Status.InternalPort); err != nil {
+				klog.Errorf("failed to create dnat %s, %v", key, err)
+				return err
+			}
 		}
 		if err = c.patchDnatStatus(key, "", "", "", "", true); err != nil {
 			klog.Errorf("failed to patch status for dnat %s, %v", key, err)
@@ -1810,6 +1862,12 @@ func (c *Controller) finalDeleteDnatInPod(key string, cachedDnat *kubeovnv1.Ipta
 	}
 	if statusV4ip == "" || statusNatGwDp == "" {
 		klog.Warningf("dnat %s: skip status-based cleanup due to incomplete identity (v4ip=%q, natGwDp=%q)", key, statusV4ip, statusNatGwDp)
+	} else if cachedDnat.Spec.Type == kubeovnv1.DnatRuleTypeShare {
+		// Share type: rebuild nft rule with remaining backends, or delete if none are left
+		if err := c.cleanupShareDnatInPod(key, statusNatGwDp, cachedDnat.Spec.EIP, statusProtocol, statusV4ip, statusExternalPort, cachedDnat.Name); err != nil {
+			klog.Error(err)
+			firstErr = err
+		}
 	} else if err := c.deleteDnatInPod(statusNatGwDp, statusProtocol,
 		statusV4ip, statusExternalPort); err != nil {
 		klog.Errorf("failed to delete dnat %s, %v", key, err)
@@ -1837,7 +1895,16 @@ func (c *Controller) finalDeleteDnatInPod(key string, cachedDnat *kubeovnv1.Ipta
 			return firstErr
 		}
 		if specV4ip != statusV4ip || specNatGwDp != statusNatGwDp || specProtocol != statusProtocol || specExternalPort != statusExternalPort {
-			if err = c.deleteDnatInPod(specNatGwDp, specProtocol, specV4ip, specExternalPort); err != nil {
+			if cachedDnat.Spec.Type == kubeovnv1.DnatRuleTypeShare {
+				// Share type: the stale rule lives in nftables, not iptables.
+				// Rebuild the nft map without this DNAT's backend, or delete entirely.
+				if err = c.cleanupShareDnatInPod(key, specNatGwDp, cachedDnat.Spec.EIP, specProtocol, specV4ip, specExternalPort, cachedDnat.Name); err != nil {
+					klog.Errorf("failed spec-based nft cleanup for dnat %s, %v", key, err)
+					if firstErr == nil {
+						firstErr = err
+					}
+				}
+			} else if err = c.deleteDnatInPod(specNatGwDp, specProtocol, specV4ip, specExternalPort); err != nil {
 				klog.Errorf("failed spec-based cleanup for dnat %s, %v", key, err)
 				if firstErr == nil {
 					firstErr = err
@@ -2054,28 +2121,6 @@ func (c *Controller) deleteSnatInPod(dp, v4ip, internalCIDR string) error {
 		return err
 	}
 	return nil
-}
-
-func (c *Controller) isDnatDuplicated(gwName, eipName, dnatName, externalPort, protocol string) (bool, error) {
-	// Check if the tuple "eip:external port:protocol" is already used by another DNAT rule
-	dnats, err := c.iptablesDnatRulesLister.List(labels.SelectorFromSet(labels.Set{
-		util.VpcNatGatewayNameLabel: gwName,
-		util.VpcDnatEPortLabel:      externalPort,
-	}))
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return false, err
-		}
-	}
-	if len(dnats) != 0 {
-		for _, d := range dnats {
-			if d.Name != dnatName && d.Spec.EIP == eipName && d.Spec.Protocol == protocol {
-				err = fmt.Errorf("failed to create dnat %s, duplicate, same eip %s, same external port '%s', same protocol'%s' is using by dnat %s", dnatName, eipName, externalPort, protocol, d.Name)
-				return true, err
-			}
-		}
-	}
-	return false, nil
 }
 
 func (c *Controller) updateIptableLabels(name, op, natType string, labels map[string]string) error {

--- a/pkg/controller/vpc_nat_gw_nat.go
+++ b/pkg/controller/vpc_nat_gw_nat.go
@@ -807,7 +807,12 @@ func (c *Controller) handleUpdateIptablesDnatRule(key string) error {
 
 		switch cachedDnat.Spec.Type {
 		case kubeovnv1.DnatRuleTypeShare:
-			// Share type: rebuild nft rule with all backends
+			// Share type: rebuild nft rule with all backends.
+			// Identity fields are read from Status (redo replays the last successfully-applied
+			// state after a gateway pod restart), except eipName which uses Spec.EIP on purpose:
+			// getShareBackends filters siblings by their Spec.EIP, so the lookup key must also be
+			// Spec.EIP to match. In the normal redo case Spec.EIP == Status EIP; they can only
+			// diverge in the rare "EIP renamed while not-yet-Ready + pod restart" corner case.
 			backends, err := c.getShareBackends(cachedDnat.Status.NatGwDp, cachedDnat.Spec.EIP, cachedDnat.Status.ExternalPort, cachedDnat.Status.Protocol, cachedDnat.Name)
 			if err != nil {
 				klog.Errorf("failed to get share backends for dnat %s: %v", key, err)

--- a/pkg/controller/vpc_nat_gw_nat_test.go
+++ b/pkg/controller/vpc_nat_gw_nat_test.go
@@ -2,12 +2,16 @@ package controller
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
 func TestValidateDnat(t *testing.T) {
@@ -547,4 +551,144 @@ func TestDeleteSnatInPod_NatGwExistsPodMissing(t *testing.T) {
 	require.NoError(t, err)
 	err = fc.fakeController.deleteSnatInPod("test-gw", "10.0.0.1", "192.168.1.0/24")
 	require.Error(t, err, "should return error to retry when pod is temporarily absent")
+}
+
+// shareDnat builds an IptablesDnatRule with the identity labels that getShareBackends
+// and isDnatDuplicated select on. dnatType may be "" (defaults to exclusive behavior).
+func shareDnat(name, gw, eip, eport, proto, intIP, intPort, dnatType string) *kubeovnv1.IptablesDnatRule {
+	return &kubeovnv1.IptablesDnatRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				util.VpcNatGatewayNameLabel: gw,
+				util.VpcDnatEPortLabel:      eport,
+			},
+		},
+		Spec: kubeovnv1.IptablesDnatRuleSpec{
+			EIP:          eip,
+			ExternalPort: eport,
+			Protocol:     proto,
+			InternalIP:   intIP,
+			InternalPort: intPort,
+			Type:         dnatType,
+		},
+	}
+}
+
+// dnatListerController returns a Controller whose iptablesDnatRulesLister is backed by the
+// given objects, so lister-based helpers can be unit tested without a running informer.
+func dnatListerController(t *testing.T, dnats ...*kubeovnv1.IptablesDnatRule) *Controller {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, d := range dnats {
+		require.NoError(t, indexer.Add(d))
+	}
+	return &Controller{iptablesDnatRulesLister: kubeovnlister.NewIptablesDnatRuleLister(indexer)}
+}
+
+func TestDedupSortedBackends(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "nil", in: nil, want: nil},
+		{name: "empty entries dropped", in: []string{"", ""}, want: nil},
+		{
+			name: "dedup and sort",
+			in:   []string{"10.0.0.2:80", "10.0.0.1:80", "10.0.0.2:80", "", "10.0.0.3:80"},
+			want: []string{"10.0.0.1:80", "10.0.0.2:80", "10.0.0.3:80"},
+		},
+		{
+			name: "already unique stays sorted",
+			in:   []string{"10.0.0.1:80", "10.0.0.2:80"},
+			want: []string{"10.0.0.1:80", "10.0.0.2:80"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, dedupSortedBackends(tt.in))
+		})
+	}
+}
+
+func TestGetShareBackends(t *testing.T) {
+	t.Parallel()
+
+	deleting := shareDnat("deleting", "gw", "eip", "80", "tcp", "10.0.0.5", "8080", kubeovnv1.DnatRuleTypeShare)
+	deleting.DeletionTimestamp = &metav1.Time{Time: time.Unix(1, 0)}
+
+	c := dnatListerController(t,
+		shareDnat("self", "gw", "eip", "80", "tcp", "10.0.0.9", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("d1", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("d2", "gw", "eip", "80", "tcp", "10.0.0.2", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("exclusive", "gw", "eip", "80", "tcp", "10.0.0.3", "8080", kubeovnv1.DnatRuleTypeExclusive),
+		shareDnat("other-proto", "gw", "eip", "80", "udp", "10.0.0.4", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("other-eip", "gw", "eip2", "80", "tcp", "10.0.0.6", "8080", kubeovnv1.DnatRuleTypeShare),
+		shareDnat("incomplete", "gw", "eip", "80", "tcp", "", "8080", kubeovnv1.DnatRuleTypeShare),
+		deleting,
+	)
+
+	backends, err := c.getShareBackends("gw", "eip", "80", "tcp", "self")
+	require.NoError(t, err)
+	// Self is excluded; only ready share siblings with the same identity are returned.
+	// Exclusive, other protocol/eip, incomplete spec and deleting rules are filtered out.
+	assert.ElementsMatch(t, []string{"10.0.0.1:8080", "10.0.0.2:8080"}, backends)
+}
+
+func TestIsDnatDuplicated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		existing *kubeovnv1.IptablesDnatRule
+		newType  string
+		wantDup  bool
+	}{
+		{
+			name:     "exclusive vs existing exclusive is duplicate",
+			existing: shareDnat("other", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeExclusive),
+			newType:  kubeovnv1.DnatRuleTypeExclusive,
+			wantDup:  true,
+		},
+		{
+			name:     "share vs existing share coexist",
+			existing: shareDnat("other", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeShare),
+			newType:  kubeovnv1.DnatRuleTypeShare,
+			wantDup:  false,
+		},
+		{
+			name:     "exclusive vs existing share is duplicate",
+			existing: shareDnat("other", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeShare),
+			newType:  kubeovnv1.DnatRuleTypeExclusive,
+			wantDup:  true,
+		},
+		{
+			name:     "share vs existing exclusive is duplicate",
+			existing: shareDnat("other", "gw", "eip", "80", "tcp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeExclusive),
+			newType:  kubeovnv1.DnatRuleTypeShare,
+			wantDup:  true,
+		},
+		{
+			name:     "different protocol is not duplicate",
+			existing: shareDnat("other", "gw", "eip", "80", "udp", "10.0.0.1", "8080", kubeovnv1.DnatRuleTypeExclusive),
+			newType:  kubeovnv1.DnatRuleTypeExclusive,
+			wantDup:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := dnatListerController(t, tt.existing)
+			dup, err := c.isDnatDuplicated("gw", "eip", "new", "80", "tcp", tt.newType)
+			assert.Equal(t, tt.wantDup, dup)
+			if tt.wantDup {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -276,6 +276,19 @@ func (v *ValidatingHook) iptablesDnatUpdateHook(ctx context.Context, req admissi
 	}
 
 	if dnatNew.Spec != dnatOld.Spec {
+		// Type is immutable after creation
+		oldType := dnatOld.Spec.Type
+		if oldType == "" {
+			oldType = ovnv1.DnatRuleTypeExclusive
+		}
+		newType := dnatNew.Spec.Type
+		if newType == "" {
+			newType = ovnv1.DnatRuleTypeExclusive
+		}
+		if oldType != newType {
+			return ctrlwebhook.Errored(http.StatusBadRequest, fmt.Errorf("dnat type is immutable after creation: cannot change from %q to %q", oldType, newType))
+		}
+
 		if err := v.ValidateVpcNatConfig(ctx); err != nil {
 			return ctrlwebhook.Errored(http.StatusBadRequest, err)
 		}
@@ -575,6 +588,53 @@ func (v *ValidatingHook) ValidateIptablesDnat(ctx context.Context, dnat *ovnv1.I
 		!strings.EqualFold(dnat.Spec.Protocol, "udp") {
 		err := fmt.Errorf("invalid iptable protocol: %s,supported params: \"tcp\", \"udp\"", dnat.Spec.Protocol)
 		return err
+	}
+
+	// Default type to Exclusive if empty
+	dnatType := dnat.Spec.Type
+	if dnatType == "" {
+		dnatType = ovnv1.DnatRuleTypeExclusive
+	}
+
+	// Share type DNAT is implemented with IPv4-only nft rules (ip daddr / ip saddr).
+	// Reject it for a v6-only EIP. EIPs that are still being allocated (both addresses
+	// empty) are allowed here; the controller requeues until the IPv4 address is ready.
+	if dnatType == ovnv1.DnatRuleTypeShare && eip.Spec.V4ip == "" && eip.Spec.V6ip != "" {
+		return fmt.Errorf("dnat %q cannot use type=share: EIP %q is IPv6-only, share dnat only supports IPv4", dnat.Name, dnat.Spec.EIP)
+	}
+
+	// Check type conflict with existing DNAT rules sharing the same identity
+	if eip.Spec.NatGwDp != "" {
+		dnatList := &ovnv1.IptablesDnatRuleList{}
+		if err := v.cache.List(ctx, dnatList, cli.MatchingLabels{
+			util.VpcNatGatewayNameLabel: eip.Spec.NatGwDp,
+			util.VpcDnatEPortLabel:      dnat.Spec.ExternalPort,
+		}); err != nil {
+			return fmt.Errorf("failed to list iptables DNAT rules: %w", err)
+		}
+
+		for _, existing := range dnatList.Items {
+			// Skip self (for update hooks)
+			if existing.Name == dnat.Name {
+				continue
+			}
+			// Only check same identity (EIP + Protocol)
+			if existing.Spec.EIP != dnat.Spec.EIP || existing.Spec.Protocol != dnat.Spec.Protocol {
+				continue
+			}
+
+			existingType := existing.Spec.Type
+			if existingType == "" {
+				existingType = ovnv1.DnatRuleTypeExclusive
+			}
+
+			// Both must be Share type to coexist
+			if dnatType != ovnv1.DnatRuleTypeShare || existingType != ovnv1.DnatRuleTypeShare {
+				return fmt.Errorf("dnat %q (type=%s) conflicts with existing dnat %q (type=%s) sharing the same identity (eip=%s, port=%s, protocol=%s): both must be type=share to coexist",
+					dnat.Name, dnatType, existing.Name, existingType,
+					dnat.Spec.EIP, dnat.Spec.ExternalPort, dnat.Spec.Protocol)
+			}
+		}
 	}
 
 	// Check FIP/DNAT exclusivity: FIP claims all traffic to the EIP (EXCLUSIVE_DNAT),

--- a/pkg/webhook/vpc_nat_gateway.go
+++ b/pkg/webhook/vpc_nat_gateway.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -563,20 +562,12 @@ func (v *ValidatingHook) ValidateIptablesDnat(ctx context.Context, dnat *ovnv1.I
 		return errors.New("parameter \"internalPort\" cannot be empty")
 	}
 
-	if port, err := strconv.Atoi(dnat.Spec.ExternalPort); err != nil {
-		errMsg := fmt.Errorf("failed to parse externalPort %s: %w", dnat.Spec.ExternalPort, err)
-		return errMsg
-	} else if port < 0 || port > 65535 {
-		err := fmt.Errorf("externalPort %s is not a valid port", dnat.Spec.ExternalPort)
-		return err
+	if err := util.ValidatePort(dnat.Spec.ExternalPort); err != nil {
+		return fmt.Errorf("externalPort %s is not a valid port: %w", dnat.Spec.ExternalPort, err)
 	}
 
-	if port, err := strconv.Atoi(dnat.Spec.InternalPort); err != nil {
-		errMsg := fmt.Errorf("failed to parse internalIP %s: %w", dnat.Spec.InternalPort, err)
-		return errMsg
-	} else if port < 0 || port > 65535 {
-		err := fmt.Errorf("internalIP %s is not a valid port", dnat.Spec.InternalPort)
-		return err
+	if err := util.ValidatePort(dnat.Spec.InternalPort); err != nil {
+		return fmt.Errorf("internalPort %s is not a valid port: %w", dnat.Spec.InternalPort, err)
 	}
 
 	if net.ParseIP(dnat.Spec.InternalIP) == nil {


### PR DESCRIPTION
Backport of kubeovn/kube-ovn#6858. 

Adds a `type` field (exclusive|share, default exclusive) to IptablesDnatRule. Share-type rules let multiple internal backends share the same EIP:port identity, load-balanced via an nftables map in the VPC NAT gateway pod.

- API: IptablesDnatRule.Spec.Type + CRD schema (enum/default) and printer column
- controller: nft_dnat.go (share reconcile, getShareBackends, isDnatDuplicated), vpc_nat_gw_nat.go add/update/delete/redo paths
- webhook: type immutability + exclusive/share conflict validation
- nat-gateway.sh: nft dnat map add/del; vpcnatgateway image installs nftables

CRDs are hand-maintained in this fork (no make gen-crd), so the type field was added manually to all three CRD copies. Upstream e2e tests are omitted (this fork removed the iptables-vpc-nat-gw e2e suite in "cleanup e2e tests").

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
