### PR TITLE
daemon: keepalive loop to auto-recover macvlan sub-interface for node-local EIP access

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -223,6 +223,7 @@ func NewController(config *Configuration,
 
 	if _, err = podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: controller.enqueueUpdatePod,
+		DeleteFunc: controller.enqueueDeletePod,
 	}); err != nil {
 		return nil, err
 	}
@@ -806,6 +807,28 @@ func (c *Controller) enqueueUpdatePod(oldObj, newObj any) {
 			}
 		}
 	}
+}
+
+func (c *Controller) enqueueDeletePod(obj any) {
+	if !c.config.EnableNodeLocalAccessVpcNatGwEIP {
+		return
+	}
+	var pod *v1.Pod
+	switch t := obj.(type) {
+	case *v1.Pod:
+		pod = t
+	case cache.DeletedFinalStateUnknown:
+		p, ok := t.Obj.(*v1.Pod)
+		if !ok {
+			klog.Warningf("unexpected object type in tombstone: %T", t.Obj)
+			return
+		}
+		pod = p
+	default:
+		klog.Warningf("unexpected type: %T", obj)
+		return
+	}
+	c.handleNatGwPodDelete(pod)
 }
 
 func (c *Controller) runUpdatePodWorker() {

--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -1000,6 +1000,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		go wait.Until(c.runMacvlanSubnetWorker, time.Second, stopCh)
 		go wait.Until(c.runIptablesEipWorker, time.Second, stopCh)
 		go wait.Until(c.runIptablesEipDeleteWorker, time.Second, stopCh)
+		go wait.Until(c.loopEnsureMacvlanSubInterfaces, 5*time.Second, stopCh)
 	}
 	go wait.Until(c.runGateway, 3*time.Second, stopCh)
 	go wait.Until(c.loopEncapIPCheck, 3*time.Second, stopCh)

--- a/pkg/daemon/node_route_to_eip_linux.go
+++ b/pkg/daemon/node_route_to_eip_linux.go
@@ -188,6 +188,10 @@ func addEIPRoute(eip, macvlanSubIfName string) error {
 		Scope:     netlink.SCOPE_LINK,
 	}
 
+	// Use RouteReplace (RTM_NEWROUTE with NLM_F_CREATE|NLM_F_REPLACE) rather than del+add:
+	// the kernel updates the FIB entry atomically, so an existing route is never removed
+	// mid-flight (no traffic gap) and a missing one is created. This makes it safe to
+	// re-apply idempotently on every keepalive cycle regardless of the current state.
 	if err := netlink.RouteReplace(route); err != nil {
 		err = fmt.Errorf("failed to add route for EIP %s via %s: %w", eip, macvlanSubIfName, err)
 		klog.Error(err)

--- a/pkg/daemon/node_route_to_eip_linux.go
+++ b/pkg/daemon/node_route_to_eip_linux.go
@@ -194,7 +194,8 @@ func addEIPRoute(eip, macvlanSubIfName string) error {
 		return err
 	}
 
-	klog.Infof("added route for EIP %s via macvlan sub-interface %s", eip, macvlanSubIfName)
+	// V(3): RouteReplace is idempotent and re-applied on every keepalive cycle.
+	klog.V(3).Infof("added route for EIP %s via macvlan sub-interface %s", eip, macvlanSubIfName)
 	return nil
 }
 
@@ -320,18 +321,20 @@ func (c *Controller) shouldDeleteMacvlanForMaster(master, excludeSubnet string) 
 }
 
 // loopEnsureMacvlanSubInterfaces is a keepalive loop that periodically ensures the
-// macvlan sub-interfaces for all macvlan-type subnets exist and are up on the node.
+// macvlan sub-interfaces for all macvlan-type subnets exist and are up on the node, and
+// that their EIP routes are present.
 //
 // The sub-interfaces are normally created once in response to subnet events. If an
 // interface is later lost or brought down (e.g. the master interface flaps, or the
 // sub-interface is deleted/set down by an external actor), there is no event to trigger
-// recovery, which previously required a manual daemon pod restart. This loop detects the
-// missing or down interface and restores it automatically.
+// recovery, which previously required a manual daemon pod restart. This loop recreates
+// the interface (createMacvlanSubInterface also brings it back up) automatically.
 //
-// The kernel flushes an interface's SCOPE_LINK routes when the interface is deleted or
-// administratively set down (IFF_UP cleared). Both cases therefore require re-syncing the
-// EIP routes after the interface is restored. A pure carrier flap (master down/up) keeps
-// the sub-interface IFF_UP and its routes intact, so it does not need a route resync.
+// The kernel flushes an interface's SCOPE_LINK routes when it is deleted or set down, so
+// after ensuring the interfaces we unconditionally re-apply the EIP routes. RouteReplace
+// is idempotent, so refreshing every cycle is cheap and, unlike detecting the exact
+// down/up transition, has no polling blind spot: no matter how the interface flaps
+// between two polls, the next cycle restores its routes.
 //
 // TOCTOU note: this loop and the subnet delete worker both act on the shared informer
 // cache from separate goroutines. If a subnet's List() snapshot here is taken just
@@ -359,49 +362,23 @@ func (c *Controller) loopEnsureMacvlanSubInterfaces() {
 		}
 	}
 
-	needResync := false
+	if len(masters) == 0 {
+		return
+	}
+
 	for master := range masters {
-		macvlanName, err := util.GenMacvlanIfaceName(master)
-		if err != nil {
-			klog.Errorf("failed to generate macvlan name for master %s: %v", master, err)
-			continue
-		}
-
-		// Detect whether the sub-interface's routes were flushed before restoring it, so
-		// we know whether EIP routes need to be re-synced afterwards. Routes are flushed
-		// when the interface is gone (recreated below) or administratively down (brought
-		// up below); a carrier flap keeps IFF_UP and its routes, so it is not counted.
-		routesFlushed := false
-		if link, err := netlink.LinkByName(macvlanName); err != nil {
-			if _, ok := err.(netlink.LinkNotFoundError); !ok {
-				klog.Errorf("failed to check macvlan sub-interface %s: %v", macvlanName, err)
-				continue
-			}
-			routesFlushed = true // interface missing, will be recreated
-		} else if link.Attrs().Flags&net.FlagUp == 0 {
-			routesFlushed = true // interface administratively down, will be brought up
-		}
-
 		if err := c.createMacvlanSubInterface(master); err != nil {
 			klog.Errorf("failed to ensure macvlan sub-interface for master %s: %v", master, err)
-			continue
-		}
-
-		if routesFlushed {
-			klog.Warningf("macvlan sub-interface %s was missing or down and has been restored", macvlanName)
-			needResync = true
 		}
 	}
 
-	// A restored interface has lost its routes, so re-add the EIP routes.
-	if needResync {
-		c.resyncLocalIptablesEipRoutes()
-	}
+	// Idempotently re-apply EIP routes every cycle so they survive any interface flap.
+	c.resyncLocalIptablesEipRoutes()
 }
 
 // resyncLocalIptablesEipRoutes re-enqueues all ready IptablesEIPs so their routes are
 // re-added on the node. The EIP route worker is idempotent and only adds routes when the
-// NAT GW pod is on the local node, so this is safe to call unconditionally.
+// NAT GW pod is on the local node, so this is safe to call on every keepalive cycle.
 func (c *Controller) resyncLocalIptablesEipRoutes() {
 	eips, err := c.iptablesEipsLister.List(labels.Everything())
 	if err != nil {
@@ -417,7 +394,8 @@ func (c *Controller) resyncLocalIptablesEipRoutes() {
 		if info == nil {
 			continue
 		}
-		klog.Infof("re-enqueue iptables-eip %s to restore route after macvlan recreation", eip.Name)
+		// V(4): this runs every keepalive cycle, so keep it quiet on the steady state.
+		klog.V(4).Infof("re-enqueue iptables-eip %s to refresh its route", eip.Name)
 		c.iptablesEipQueue.Add(*info)
 	}
 }
@@ -639,7 +617,7 @@ func (c *Controller) processNextIptablesEipItem() bool {
 // syncIptablesEipRoute syncs the route for an IptablesEIP.
 // It adds the route if NAT GW pod is on this node, or deletes the route if not.
 func (c *Controller) syncIptablesEipRoute(info eipRouteInfo) error {
-	klog.Infof("syncing iptables-eip route for %s", info.eipName)
+	klog.V(3).Infof("syncing iptables-eip route for %s", info.eipName)
 
 	// Check if EIP was deleted - skip if it was to prevent race conditions
 	if _, deleted := c.deletedEIPs.Load(info.eipName); deleted {

--- a/pkg/daemon/node_route_to_eip_linux.go
+++ b/pkg/daemon/node_route_to_eip_linux.go
@@ -29,8 +29,9 @@ package daemon
 //     - Delete: enqueueDeleteIptablesEip → iptablesEipDeleteQueue
 //       → runIptablesEipDeleteWorker() → handleDeleteIptablesEipRoute() → deleteEIPRoute()
 //
-//  3. NAT GW Pod event (pod update with VpcNatGatewayLabel):
-//     enqueueUpdatePod() → handleNatGwPodUpdate() → enqueueEipsForNatGw()
+//  3. NAT GW Pod event (pod with VpcNatGatewayLabel):
+//     - Update: enqueueUpdatePod() → handleNatGwPodUpdate() → enqueueEipsForNatGw()
+//     - Delete: enqueueDeletePod() → handleNatGwPodDelete() → enqueueEipsForNatGw()
 //     → syncIptablesEipRoute() → addEIPRoute() / deleteEIPRoute()
 //
 // Prerequisites:
@@ -380,9 +381,17 @@ func (c *Controller) loopEnsureMacvlanSubInterfaces() {
 	c.resyncLocalIptablesEipRoutes()
 }
 
-// resyncLocalIptablesEipRoutes re-enqueues all ready IptablesEIPs so their routes are
-// re-added on the node. The EIP route worker is idempotent and only adds routes when the
-// NAT GW pod is on the local node, so this is safe to call on every keepalive cycle.
+// resyncLocalIptablesEipRoutes re-enqueues all ready IptablesEIPs so the route worker can
+// converge each one on this node: syncIptablesEipRoute adds the route when the NAT GW pod
+// is local and deletes it otherwise.
+//
+// It deliberately processes every ready EIP, not just local ones. The pod informer here is
+// node-scoped and only has an update handler, so when a NAT GW pod is rescheduled to
+// another node the old node reliably gets neither a usable update (Case 1 of
+// handleNatGwPodUpdate cannot fire under a node-scoped informer) nor a delete event. This
+// periodic full pass is what removes the now-stale route on the node the pod moved away
+// from, and also self-heals after a daemon restart. Skipping non-local EIPs would leak
+// those routes.
 func (c *Controller) resyncLocalIptablesEipRoutes() {
 	eips, err := c.iptablesEipsLister.List(labels.Everything())
 	if err != nil {
@@ -399,7 +408,7 @@ func (c *Controller) resyncLocalIptablesEipRoutes() {
 			continue
 		}
 		// V(4): this runs every keepalive cycle, so keep it quiet on the steady state.
-		klog.V(4).Infof("re-enqueue iptables-eip %s to refresh its route", eip.Name)
+		klog.V(4).Infof("re-enqueue iptables-eip %s to sync its route", eip.Name)
 		c.iptablesEipQueue.Add(*info)
 	}
 }
@@ -746,4 +755,23 @@ func (c *Controller) handleNatGwPodUpdate(oldPod, newPod *corev1.Pod) {
 		klog.Infof("NAT GW pod %s no longer running on this node (phase: %s), enqueuing EIPs to delete routes", newPod.Name, newPod.Status.Phase)
 		c.enqueueEipsForNatGw(natGwName)
 	}
+}
+
+// handleNatGwPodDelete handles NAT GW pod delete events. The pod informer is node-scoped,
+// so a delete event only reaches the node the pod was running on, which is exactly where
+// its EIP routes become stale. Enqueue the gateway's EIPs so the route worker removes them
+// promptly instead of waiting for the periodic resync (the route worker deletes the routes
+// because the NAT GW pod is no longer local).
+func (c *Controller) handleNatGwPodDelete(pod *corev1.Pod) {
+	if !isVpcNatGwPod(pod) {
+		return
+	}
+
+	natGwName := getNatGwNameFromPod(pod)
+	if natGwName == "" {
+		return
+	}
+
+	klog.Infof("NAT GW pod %s deleted from this node, enqueuing EIPs to delete routes", pod.Name)
+	c.enqueueEipsForNatGw(natGwName)
 }

--- a/pkg/daemon/node_route_to_eip_linux.go
+++ b/pkg/daemon/node_route_to_eip_linux.go
@@ -323,11 +323,15 @@ func (c *Controller) shouldDeleteMacvlanForMaster(master, excludeSubnet string) 
 // macvlan sub-interfaces for all macvlan-type subnets exist and are up on the node.
 //
 // The sub-interfaces are normally created once in response to subnet events. If an
-// interface is later lost (e.g. the master interface flaps, or the sub-interface is
-// deleted by an external actor), there is no event to trigger recreation, which
-// previously required a manual daemon pod restart to recover. This loop detects the
-// missing interface and recreates it automatically. When an interface is recreated,
-// its EIP routes are lost as well, so the affected EIP routes are re-synced.
+// interface is later lost or brought down (e.g. the master interface flaps, or the
+// sub-interface is deleted/set down by an external actor), there is no event to trigger
+// recovery, which previously required a manual daemon pod restart. This loop detects the
+// missing or down interface and restores it automatically.
+//
+// The kernel flushes an interface's SCOPE_LINK routes when the interface is deleted or
+// administratively set down (IFF_UP cleared). Both cases therefore require re-syncing the
+// EIP routes after the interface is restored. A pure carrier flap (master down/up) keeps
+// the sub-interface IFF_UP and its routes intact, so it does not need a route resync.
 //
 // TOCTOU note: this loop and the subnet delete worker both act on the shared informer
 // cache from separate goroutines. If a subnet's List() snapshot here is taken just
@@ -355,7 +359,7 @@ func (c *Controller) loopEnsureMacvlanSubInterfaces() {
 		}
 	}
 
-	recreated := false
+	needResync := false
 	for master := range masters {
 		macvlanName, err := util.GenMacvlanIfaceName(master)
 		if err != nil {
@@ -363,15 +367,19 @@ func (c *Controller) loopEnsureMacvlanSubInterfaces() {
 			continue
 		}
 
-		// Detect whether the sub-interface is missing before (re)creating it so we
-		// know whether EIP routes need to be restored afterwards.
-		missing := false
-		if _, err := netlink.LinkByName(macvlanName); err != nil {
+		// Detect whether the sub-interface's routes were flushed before restoring it, so
+		// we know whether EIP routes need to be re-synced afterwards. Routes are flushed
+		// when the interface is gone (recreated below) or administratively down (brought
+		// up below); a carrier flap keeps IFF_UP and its routes, so it is not counted.
+		routesFlushed := false
+		if link, err := netlink.LinkByName(macvlanName); err != nil {
 			if _, ok := err.(netlink.LinkNotFoundError); !ok {
 				klog.Errorf("failed to check macvlan sub-interface %s: %v", macvlanName, err)
 				continue
 			}
-			missing = true
+			routesFlushed = true // interface missing, will be recreated
+		} else if link.Attrs().Flags&net.FlagUp == 0 {
+			routesFlushed = true // interface administratively down, will be brought up
 		}
 
 		if err := c.createMacvlanSubInterface(master); err != nil {
@@ -379,14 +387,14 @@ func (c *Controller) loopEnsureMacvlanSubInterfaces() {
 			continue
 		}
 
-		if missing {
-			klog.Warningf("macvlan sub-interface %s was missing and has been recreated", macvlanName)
-			recreated = true
+		if routesFlushed {
+			klog.Warningf("macvlan sub-interface %s was missing or down and has been restored", macvlanName)
+			needResync = true
 		}
 	}
 
-	// A recreated interface starts with no routes, so restore the EIP routes.
-	if recreated {
+	// A restored interface has lost its routes, so re-add the EIP routes.
+	if needResync {
 		c.resyncLocalIptablesEipRoutes()
 	}
 }

--- a/pkg/daemon/node_route_to_eip_linux.go
+++ b/pkg/daemon/node_route_to_eip_linux.go
@@ -319,6 +319,101 @@ func (c *Controller) shouldDeleteMacvlanForMaster(master, excludeSubnet string) 
 	return true
 }
 
+// loopEnsureMacvlanSubInterfaces is a keepalive loop that periodically ensures the
+// macvlan sub-interfaces for all macvlan-type subnets exist and are up on the node.
+//
+// The sub-interfaces are normally created once in response to subnet events. If an
+// interface is later lost (e.g. the master interface flaps, or the sub-interface is
+// deleted by an external actor), there is no event to trigger recreation, which
+// previously required a manual daemon pod restart to recover. This loop detects the
+// missing interface and recreates it automatically. When an interface is recreated,
+// its EIP routes are lost as well, so the affected EIP routes are re-synced.
+//
+// TOCTOU note: this loop and the subnet delete worker both act on the shared informer
+// cache from separate goroutines. If a subnet's List() snapshot here is taken just
+// before the subnet deletion propagates, the delete worker may remove the interface in
+// between, and this loop then recreates it as an orphan (no subnet references its
+// master anymore, so nothing deletes it afterwards). The impact is bounded and benign:
+// a macvlan NAD/subnet is effectively a cluster singleton that is meant to persist, so
+// deletion (and thus this window) is extremely rare; an orphaned sub-interface carries
+// no IP and no routes, so it causes no network issues and only occurs when the feature
+// is being torn down anyway.
+func (c *Controller) loopEnsureMacvlanSubInterfaces() {
+	subnets, err := c.subnetsLister.List(labels.SelectorFromSet(labels.Set{
+		util.NadMacvlanTypeLabel: "true",
+	}))
+	if err != nil {
+		klog.Errorf("failed to list macvlan subnets: %v", err)
+		return
+	}
+
+	// Collect the set of unique master interfaces in use by macvlan subnets.
+	masters := make(map[string]struct{})
+	for _, subnet := range subnets {
+		if master := subnet.Annotations[util.NadMacvlanMasterAnnotation]; master != "" {
+			masters[master] = struct{}{}
+		}
+	}
+
+	recreated := false
+	for master := range masters {
+		macvlanName, err := util.GenMacvlanIfaceName(master)
+		if err != nil {
+			klog.Errorf("failed to generate macvlan name for master %s: %v", master, err)
+			continue
+		}
+
+		// Detect whether the sub-interface is missing before (re)creating it so we
+		// know whether EIP routes need to be restored afterwards.
+		missing := false
+		if _, err := netlink.LinkByName(macvlanName); err != nil {
+			if _, ok := err.(netlink.LinkNotFoundError); !ok {
+				klog.Errorf("failed to check macvlan sub-interface %s: %v", macvlanName, err)
+				continue
+			}
+			missing = true
+		}
+
+		if err := c.createMacvlanSubInterface(master); err != nil {
+			klog.Errorf("failed to ensure macvlan sub-interface for master %s: %v", master, err)
+			continue
+		}
+
+		if missing {
+			klog.Warningf("macvlan sub-interface %s was missing and has been recreated", macvlanName)
+			recreated = true
+		}
+	}
+
+	// A recreated interface starts with no routes, so restore the EIP routes.
+	if recreated {
+		c.resyncLocalIptablesEipRoutes()
+	}
+}
+
+// resyncLocalIptablesEipRoutes re-enqueues all ready IptablesEIPs so their routes are
+// re-added on the node. The EIP route worker is idempotent and only adds routes when the
+// NAT GW pod is on the local node, so this is safe to call unconditionally.
+func (c *Controller) resyncLocalIptablesEipRoutes() {
+	eips, err := c.iptablesEipsLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list iptables-eips for route resync: %v", err)
+		return
+	}
+
+	for _, eip := range eips {
+		if !shouldEnqueueIptablesEip(eip) {
+			continue
+		}
+		info := c.buildEipRouteInfo(eip)
+		if info == nil {
+			continue
+		}
+		klog.Infof("re-enqueue iptables-eip %s to restore route after macvlan recreation", eip.Name)
+		c.iptablesEipQueue.Add(*info)
+	}
+}
+
 // hasNatGwPodOnLocalNode checks if the NAT GW pod for the given NatGwDp is scheduled on the local node.
 // NAT GW pod name is generated from NatGwDp field using the pattern: vpc-nat-gw-{natGwDp}-0
 // Note: This only checks NodeName, not pod phase. The caller should check EIP Ready status

--- a/pkg/daemon/node_route_to_eip_linux_test.go
+++ b/pkg/daemon/node_route_to_eip_linux_test.go
@@ -349,10 +349,84 @@ func TestResyncLocalIptablesEipRoutes(t *testing.T) {
 
 	c.resyncLocalIptablesEipRoutes()
 
-	// Only the ready EIP backed by a subnet with a macvlan master should be enqueued.
+	// Only the ready EIP backed by a subnet with a macvlan master should be enqueued;
+	// the route worker (not exercised here) later decides add vs delete by NAT GW locality.
 	require.Equal(t, 1, c.iptablesEipQueue.Len())
 	item, _ := c.iptablesEipQueue.Get()
 	assert.Equal(t, "eip-ready", item.eipName)
 	assert.Equal(t, "1.1.1.1", item.v4ip)
 	assert.Equal(t, macvlanName, item.macvlanName)
+}
+
+func TestHandleNatGwPodDelete(t *testing.T) {
+	const (
+		master    = "eth0"
+		natGwName = "gw1"
+	)
+	macvlanName, err := util.GenMacvlanIfaceName(master)
+	require.NoError(t, err)
+
+	subnetWithMaster := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ext-subnet",
+			Annotations: map[string]string{util.NadMacvlanMasterAnnotation: master},
+		},
+	}
+	eip := &kubeovnv1.IptablesEIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "eip-1",
+			Labels: map[string]string{util.VpcNatGatewayNameLabel: natGwName},
+		},
+		Spec: kubeovnv1.IptablesEIPSpec{
+			V4ip:           "1.1.1.1",
+			ExternalSubnet: "ext-subnet",
+			NatGwDp:        natGwName,
+		},
+		Status: kubeovnv1.IptablesEIPStatus{Ready: true},
+	}
+
+	subnetIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, subnetIndexer.Add(subnetWithMaster))
+	eipIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, eipIndexer.Add(eip))
+
+	newController := func() *Controller {
+		return &Controller{
+			subnetsLister:      kubeovnlister.NewSubnetLister(subnetIndexer),
+			iptablesEipsLister: kubeovnlister.NewIptablesEIPLister(eipIndexer),
+			iptablesEipQueue:   newTypedRateLimitingQueue[eipRouteInfo]("test-natgw-delete", nil),
+		}
+	}
+
+	t.Run("nat gw pod delete enqueues its eips", func(t *testing.T) {
+		c := newController()
+		defer c.iptablesEipQueue.ShutDown()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: util.GenNatGwPodName(natGwName),
+				Labels: map[string]string{
+					util.VpcNatGatewayLabel:     "true",
+					util.VpcNatGatewayNameLabel: natGwName,
+				},
+			},
+		}
+		c.handleNatGwPodDelete(pod)
+
+		require.Equal(t, 1, c.iptablesEipQueue.Len())
+		item, _ := c.iptablesEipQueue.Get()
+		assert.Equal(t, "eip-1", item.eipName)
+		assert.Equal(t, "1.1.1.1", item.v4ip)
+		assert.Equal(t, macvlanName, item.macvlanName)
+	})
+
+	t.Run("non nat gw pod is ignored", func(t *testing.T) {
+		c := newController()
+		defer c.iptablesEipQueue.ShutDown()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "some-pod", Labels: map[string]string{"app": "test"}},
+		}
+		c.handleNatGwPodDelete(pod)
+
+		assert.Equal(t, 0, c.iptablesEipQueue.Len())
+	})
 }

--- a/pkg/daemon/node_route_to_eip_linux_test.go
+++ b/pkg/daemon/node_route_to_eip_linux_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
@@ -291,4 +293,66 @@ func TestDeletedEIPsStateManagement(t *testing.T) {
 		assert.False(t, exists1, "eip-1 should be cleared")
 		assert.True(t, exists2, "eip-2 should still be marked")
 	})
+}
+
+func TestResyncLocalIptablesEipRoutes(t *testing.T) {
+	const master = "eth0"
+	macvlanName, err := util.GenMacvlanIfaceName(master)
+	require.NoError(t, err)
+
+	newEIP := func(name, v4ip, externalSubnet string, ready bool) *kubeovnv1.IptablesEIP {
+		return &kubeovnv1.IptablesEIP{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kubeovnv1.IptablesEIPSpec{
+				V4ip:           v4ip,
+				ExternalSubnet: externalSubnet,
+			},
+			Status: kubeovnv1.IptablesEIPStatus{Ready: ready},
+		}
+	}
+
+	// subnetWithMaster resolves buildEipRouteInfo; subnetNoMaster makes it return nil.
+	subnetWithMaster := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ext-subnet",
+			Annotations: map[string]string{util.NadMacvlanMasterAnnotation: master},
+		},
+	}
+	subnetNoMaster := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ext-subnet-no-master"},
+	}
+
+	eips := []*kubeovnv1.IptablesEIP{
+		newEIP("eip-ready", "1.1.1.1", "ext-subnet", true),                      // enqueued
+		newEIP("eip-not-ready", "1.1.1.2", "ext-subnet", false),                 // skip: not ready
+		newEIP("eip-no-external-subnet", "1.1.1.3", "", true),                   // skip: no ExternalSubnet
+		newEIP("eip-no-v4ip", "", "ext-subnet", true),                           // skip: buildEipRouteInfo nil
+		newEIP("eip-subnet-no-master", "1.1.1.4", "ext-subnet-no-master", true), // skip: no master
+		newEIP("eip-subnet-missing", "1.1.1.5", "nonexistent", true),            // skip: subnet not found
+	}
+
+	subnetIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, subnetIndexer.Add(subnetWithMaster))
+	require.NoError(t, subnetIndexer.Add(subnetNoMaster))
+
+	eipIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, eip := range eips {
+		require.NoError(t, eipIndexer.Add(eip))
+	}
+
+	c := &Controller{
+		subnetsLister:      kubeovnlister.NewSubnetLister(subnetIndexer),
+		iptablesEipsLister: kubeovnlister.NewIptablesEIPLister(eipIndexer),
+		iptablesEipQueue:   newTypedRateLimitingQueue[eipRouteInfo]("test-iptables-eip", nil),
+	}
+	defer c.iptablesEipQueue.ShutDown()
+
+	c.resyncLocalIptablesEipRoutes()
+
+	// Only the ready EIP backed by a subnet with a macvlan master should be enqueued.
+	require.Equal(t, 1, c.iptablesEipQueue.Len())
+	item, _ := c.iptablesEipQueue.Get()
+	assert.Equal(t, "eip-ready", item.eipName)
+	assert.Equal(t, "1.1.1.1", item.v4ip)
+	assert.Equal(t, macvlanName, item.macvlanName)
 }


### PR DESCRIPTION
The macvlan sub-interface for node-local VPC NAT GW EIP access was created only in response to subnet events, so if it was later lost (master interface flap or external deletion) recovery required a manual daemon pod restart.

Add loopEnsureMacvlanSubInterfaces to periodically ensure the sub-interfaces for all macvlan-type subnets exist and are up, recreating any missing one and re-syncing the affected EIP routes (lost together with the interface).

# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
