### PR TITLE
controller: guarantee tunnel_key annotation before CNI ADD and restart

### DIFF
--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -47,27 +47,27 @@ the population flow 2 repairs.
 - Pods that already carry the annotation keep it (persisted in etcd).
 - Legacy pods allocated before the subnet tunnel key was synced (or before
   this code existed) can have a missing, non-numeric or out-of-range
-  annotation (valid OVN tunnel keys are `1..16777215`). On startup
-  `InitIPAM` enqueues them into the dedicated
-  `repairTunnelKeyQueue` (`enqueuePodTunnelKeyRepair`); the repair worker
-  (`handleRepairTunnelKey`) patches them from `subnet.Status.TunnelKey`,
-  retrying indefinitely with exponential backoff capped at one minute and
-  an aggregate 10-qps token bucket until the key becomes available (subnet
-  reconcile may still be syncing it).
+  annotation (valid OVN tunnel keys are `1..16777215`). On startup,
+  `InitIPAM` calls `repairPodTunnelKeyOnStartup`, which invokes
+  `handleRepairTunnelKey` synchronously using `subnet.Status.TunnelKey`.
+  If it cannot finish, the dedicated queue retries indefinitely with
+  exponential backoff capped at one minute and an aggregate 10-qps token
+  bucket (subnet reconcile may still be syncing the key).
 
-The repair enqueue runs only during the InitIPAM startup sweep. It is driven
-by persisted pod annotations (`podProvidersNeedingTunnelKeyRepair`) before
-NAD/default-subnet resolution, so every eligible legacy pod is enqueued once
-without a periodic task or a pod-update fallback. The queue is necessarily
-asynchronous because InitIPAM runs before `startWorkers`; a missing subnet key
-may require the subnet worker, so waiting synchronously in InitIPAM would
-block the worker that produces it. Repair workers start afterward and retry
-with rate limiting. Detection and successful repair are logged at Warning
-level, including the instruction to restart Cilium after backfill so
-already-created endpoints reload the corrected VNI.
+InitIPAM first attempts every eligible repair synchronously, using persisted
+pod annotations (`podProvidersNeedingTunnelKeyRepair`) before NAD/default-
+subnet resolution. If subnet status is already valid, the pod is fixed before
+InitIPAM continues. Only an unavailable key or transient API error is queued.
+That asynchronous fallback is necessary because InitIPAM runs before
+`startWorkers`; a missing key may require the subnet worker, so waiting for it
+inside InitIPAM would block the worker that produces it. Deferred repairs run
+with rate limiting after workers start. There is no periodic task or pod-update
+fallback. Detection and successful repair are logged at Warning level,
+including the instruction to restart Cilium after backfill so already-created
+endpoints reload the corrected VNI.
 
-This asynchronous repair is fallback recovery only; it is not part of normal
-pod allocation. Normal allocation writes IP/network, tunnel_key and
+The deferred asynchronous repair is fallback recovery only; it is not part of
+normal pod allocation. Normal allocation writes IP/network, tunnel_key and
 `allocated=true` in one pod annotation patch.
 
 Repair is multi-NIC aware and driven by the per-provider annotations the

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -113,12 +113,11 @@ TunnelKey value.
 ## Intended upgrade sequence
 
 Restart kube-ovn-controller first (flow 2 backfills the annotations), then
-restart cilium so it re-reads them for already-created endpoints. For every
-new CNI ADD on a non-vlan OVN VPC subnet, the CNI server waits for an OVN
-logical_switch, `allocated=true`, and a valid annotation equal to
-`Subnet.Status.TunnelKey`;
-if backfill has not completed within the wait loop, ADD fails and kubelet
-retries. The cilium restart is still required for endpoints created before
+restart cilium so it re-reads them for already-created endpoints. Every CNI
+ADD waits for `allocated=true`; when the persisted logical_switch resolves to
+a non-vlan OVN VPC subnet, it additionally waits for a valid annotation equal
+to `Subnet.Status.TunnelKey`. If backfill has not completed within the wait
+loop, ADD fails and kubelet retries. The cilium restart is still required for endpoints created before
 the backfill logic existed.
 
 ## Compatibility and rolling upgrade
@@ -134,9 +133,11 @@ Two behavior changes are intentional:
   `status.tunnelKey=0` and no pod tunnel_key annotation. Older controller
   versions may have populated those values even though native-vpc identity
   does not consume them; startup reconciliation removes those stale values.
-- The new daemon fails CNI ADD for an OVN VPC provider until logical_switch,
-  `allocated=true`, and the matching tunnel_key are visible. This converts a
-  previously possible legacy race into a retryable CNI failure.
+- The new daemon fails CNI ADD for a provider whose logical_switch resolves
+  to an OVN VPC subnet until `allocated=true` and the matching tunnel_key are
+  visible. This converts a previously possible legacy race into a retryable
+  CNI failure. A provider without logical_switch is not classified as VPC and
+  keeps the old no-key behavior (required by NoDefaultEIP/IPAM-only networks).
 
 For rolling upgrades, restart/upgrade kube-ovn-controller first, wait for the
 startup repair warnings to complete, then restart/upgrade kube-ovn-daemon and
@@ -146,9 +147,9 @@ patch. Rollback is safe: an older controller may repopulate VLAN tunnel-key
 status, and a subsequent new-controller startup cleans it again.
 
 Non-primary-CNI remains compatible: non-vlan OVN attachment providers use the
-same per-provider annotation contract. IPAM-only attachments remain compatible
-when they use a non-OVN provider as designed; such providers legitimately have
-no OVN logical_switch and bypass the VPC key gate.
+same per-provider annotation contract. IPAM-only and NoDefaultEIP attachments
+without a persisted logical_switch bypass the VPC key gate, including legacy
+provider naming.
 
 ## Known gaps (documented, not closed by code)
 

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -52,9 +52,13 @@ Repair is multi-NIC aware and driven purely by the per-provider annotations
 the allocation wrote (`allocated` + `logical_switch`): every OVN subnet has
 its own `tunnel_key` annotation. A provider is repaired only if it is
 marked allocated and its `logical_switch` annotation resolves to an OVN
-subnet. An allocated provider with an empty `logical_switch` is a non-OVN
-NIC (Vlan/underlay) and is skipped silently - the OVN allocation path
-always writes `logical_switch`, so the empty case reliably means non-OVN.
+subnet. An allocated provider with an empty `logical_switch` is a NIC whose
+subnet provider is not ovn (kube-ovn acts as IPAM only, another CNI
+configures the NIC) and is skipped silently - the OVN allocation path
+always writes `logical_switch`, so the empty case reliably means no
+tunnel_key is ever written. Note that vlan/underlay subnets keep provider
+`ovn`: they are part of this mechanism (the allocation gate also applies,
+so underlay pods wait for the tunnel key before IP allocation).
 The subnet is never guessed from namespace/default fallbacks, because
 writing a wrong VNI is worse than a missing one (nothing would correct it
 afterwards); a `logical_switch` that does not resolve is counted by
@@ -80,11 +84,17 @@ corrected by the ordered cilium restart.
   `pod_tunnel_key_repair_skipped_total` (repairs skipped because the
   logical_switch subnet no longer exists) - see
   pkg/controller/tunnel_key_metrics.go.
-- Repair keying is per `podNet.ProviderName` (the `*.kubernetes.io/*`
-  annotation templates). Cilium currently only recognizes the primary NIC
+- Repair keying is per provider parsed from the `*.kubernetes.io/allocated`
+  annotation suffix (the same `*.kubernetes.io/*` templates as the
+  allocation path). Cilium currently only recognizes the primary NIC
   (default provider, `ovn.kubernetes.io/*` annotations), so a mismatch on
   a multus secondary NIC would be harmless today; it only matters if
   Cilium starts keying secondary NICs.
+- A pod whose `logical_switch` subnet no longer exists is skipped (counted
+  by `pod_tunnel_key_repair_skipped_total`) and not retried: the repair
+  queue forgets it, and there is no periodic resync. It is re-enqueued on
+  the next pod update event or the next controller restart - acceptable
+  because the pod usually cannot survive its subnet's deletion anyway.
 - The upgrade sequence above is operator discipline, not enforced by code:
   restarting cilium before the backfill completes leaves already-created
   endpoints on the non-VPC scheme until the next cilium restart.

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -40,11 +40,13 @@ the population flow 2 repairs.
   allocation path and is unrelated to restarts).
 - Pods that already carry the annotation keep it (persisted in etcd).
 - Legacy pods allocated before the subnet tunnel key was synced (or before
-  this code existed) are missing the annotation. On startup `InitIPAM`
-  enqueues them into the dedicated `repairTunnelKeyQueue`
-  (`enqueuePodTunnelKeyRepair`); the repair worker
+  this code existed) can have a missing, non-numeric or out-of-range
+  annotation (valid OVN tunnel keys are `1..16777215`). On startup
+  `InitIPAM` enqueues them into the dedicated
+  `repairTunnelKeyQueue` (`enqueuePodTunnelKeyRepair`); the repair worker
   (`handleRepairTunnelKey`) patches them from `subnet.Status.TunnelKey`,
-  retrying with unbounded backoff until the key becomes available (subnet
+  retrying indefinitely with exponential backoff capped at one minute and
+  an aggregate 10-qps token bucket until the key becomes available (subnet
   reconcile may still be syncing it).
 
 Enqueue is not one-shot: the enqueue is annotation-driven
@@ -55,9 +57,9 @@ event.
 
 Repair is multi-NIC aware and driven purely by the per-provider annotations
 the allocation wrote (`allocated` + `logical_switch`): every OVN subnet has
-its own `tunnel_key` annotation. A provider is repaired only if it is
-marked allocated and its `logical_switch` annotation resolves to an OVN
-subnet. An allocated provider with an empty `logical_switch` is a NIC whose
+its own valid `tunnel_key` annotation. A provider is repaired if its key is
+missing, non-numeric or outside `1..16777215`, and only if it is marked
+allocated and its `logical_switch` annotation resolves to an OVN subnet. An allocated provider with an empty `logical_switch` is a NIC whose
 subnet provider is not ovn (kube-ovn acts as IPAM only, another CNI
 configures the NIC) and is skipped silently - the OVN allocation path
 always writes `logical_switch`, so the empty case reliably means no

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -42,12 +42,11 @@ flow 2 repairs.
   retrying with unbounded backoff until the key becomes available (subnet
   reconcile may still be syncing it).
 
-Enqueue is not one-shot: the pod reconcile path (`handleAddOrUpdatePod`)
-and a post-start resync (`resyncPodTunnelKey`, bounded to a backfill
-window of `tunnelKeyResyncWindow`) also enqueue repairs, so a pod the
-startup sweep missed (e.g. its NAD or default subnet could not be resolved
-at that moment) heals on the next pod update event, or on a resync tick
-within the window, instead of requiring another controller restart.
+Enqueue is not one-shot: the enqueue is annotation-driven
+(`podProvidersMissingTunnelKey`), so the startup sweep cannot skip a pod
+because its NAD or default subnet could not be resolved at that moment; the
+pod reconcile path (`handleAddOrUpdatePod`) re-enqueues on any later update
+event.
 
 Repair is multi-NIC aware and driven purely by the per-provider annotations
 the allocation wrote (`allocated` + `logical_switch`): every OVN subnet has
@@ -75,10 +74,12 @@ corrected by the ordered cilium restart.
 
 ## Known gaps (documented, not closed by code)
 
-- Repair progress is observable via `pod_tunnel_key_missing` (gap size at
-  the last resync during the post-start backfill window),
-  `pod_tunnel_key_repair_total` and `pod_tunnel_key_repair_skipped_total`
-  (see pkg/controller/tunnel_key_metrics.go).
+- Repair progress is observable via `pod_tunnel_key_repair_patch_total`
+  (annotation patches that wrote one or more tunnel_key annotations; a
+  multi-NIC pod can be patched more than once) and
+  `pod_tunnel_key_repair_skipped_total` (repairs skipped because the
+  logical_switch subnet no longer exists) - see
+  pkg/controller/tunnel_key_metrics.go.
 - Repair keying is per `podNet.ProviderName` (the `*.kubernetes.io/*`
   annotation templates). Cilium currently only recognizes the primary NIC
   (default provider, `ovn.kubernetes.io/*` annotations), so a mismatch on

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -53,11 +53,16 @@ Repair is multi-NIC aware and driven purely by the per-provider annotations
 the allocation wrote (`allocated` + `logical_switch`): every OVN subnet has
 its own `tunnel_key` annotation. A provider is repaired only if it is
 marked allocated and its `logical_switch` annotation resolves to an OVN
-subnet; the subnet is never guessed from namespace/default fallbacks,
-because writing a wrong VNI is worse than a missing one (nothing would
-correct it afterwards). Progress is not all-or-nothing: ready providers are
-patched in one call even when another provider's subnet key is still 0 (the
-handler then returns an error to requeue for the remainder).
+subnet. An allocated provider with an empty `logical_switch` is a non-OVN
+NIC (Vlan/underlay) and is skipped silently - the OVN allocation path
+always writes `logical_switch`, so the empty case reliably means non-OVN.
+The subnet is never guessed from namespace/default fallbacks, because
+writing a wrong VNI is worse than a missing one (nothing would correct it
+afterwards); a `logical_switch` that does not resolve is counted by
+`pod_tunnel_key_repair_skipped_total` as the anomaly it is. Progress is
+not all-or-nothing: ready providers are patched in one call even when
+another provider's subnet key is still 0 (the handler then returns an
+error to requeue for the remainder).
 
 ## Intended upgrade sequence
 

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -55,11 +55,10 @@ the population flow 2 repairs.
   an aggregate 10-qps token bucket until the key becomes available (subnet
   reconcile may still be syncing it).
 
-Enqueue is not one-shot: reconciliation is annotation-driven
-(`podProvidersNeedingTunnelKeyRepair`), so the startup sweep cannot skip a pod
-because its NAD or default subnet could not be resolved at that moment; the
-pod reconcile path (`handleAddOrUpdatePod`) re-enqueues on any later update
-event.
+The repair enqueue runs only during the InitIPAM startup sweep. It is driven
+by persisted pod annotations (`podProvidersNeedingTunnelKeyRepair`) before
+NAD/default-subnet resolution, so every eligible legacy pod is enqueued once
+without a periodic task or a pod-update fallback.
 
 Repair is multi-NIC aware and driven by the per-provider annotations the
 allocation wrote (`allocated` + `logical_switch`). A provider is repaired
@@ -127,9 +126,10 @@ the backfill logic existed.
   Cilium starts keying secondary NICs.
 - A pod whose `logical_switch` subnet no longer exists is skipped (counted
   by `pod_tunnel_key_repair_skipped_total`) and not retried: the repair
-  queue forgets it, and there is no periodic resync. It is re-enqueued on
-  the next pod update event or the next controller restart - acceptable
-  because the pod usually cannot survive its subnet's deletion anyway.
+  queue forgets it, and there is no periodic or pod-update resync. It is
+  reconsidered on the next controller restart - acceptable because the pod
+  usually cannot survive its subnet's deletion anyway, and accidental manual
+  deletion is outside this guarantee.
 - The upgrade sequence above is operator discipline, not enforced by code:
   restarting cilium before the backfill completes leaves already-created
   endpoints on the non-VPC scheme until the next cilium restart. This affects

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -17,8 +17,8 @@ The guarantee is upheld by two flows:
 
 `reconcileAllocateSubnets` (pkg/controller/pod.go) refuses to complete the
 allocation (requeues, persisting no pod annotations) while the resolved
-subnet's tunnel key has not been synced from OVN SB
-(`Status.TunnelKey == 0`), and writes the tunnel_key annotation in the same
+subnet's tunnel key is not valid (`Status.TunnelKey` is outside
+`1..16777215`), and writes the tunnel_key annotation in the same
 atomic patch as `allocated=true`. For a non-vlan OVN VPC subnet, the
 kube-ovn CNI server blocks until `allocated=true` and the pod annotation is
 a valid value equal to `Subnet.Status.TunnelKey`. Cilium (chained after
@@ -44,7 +44,7 @@ the population flow 2 repairs.
 
 - Pods created after the restart follow flow 1 (the gate lives in the
   allocation path and is unrelated to restarts).
-- Pods that already carry the annotation keep it (persisted in etcd).
+- Pods whose persisted annotation is valid and matches subnet status keep it.
 - Legacy pods allocated before the subnet tunnel key was synced (or before
   this code existed) can have a missing, non-numeric or out-of-range
   annotation (valid OVN tunnel keys are `1..16777215`). On startup,
@@ -74,8 +74,8 @@ Repair is multi-NIC aware and driven by the per-provider annotations the
 allocation wrote (`allocated` + `logical_switch`). A provider is repaired
 only when its logical switch resolves to a non-vlan OVN VPC subnet and its
 key is missing, invalid or different from `subnet.Status.TunnelKey`.
-Providers managed by another CNI have no `logical_switch`; OVN vlan/underlay subnets have one but
-are filtered by `isOvnVpcSubnet`. Both keep no pod tunnel_key annotation;
+Providers managed by another CNI have no `logical_switch`; OVN
+vlan/underlay subnets have one but are filtered by `isOvnVpcSubnet`. Both keep no pod tunnel_key annotation;
 startup repair removes stale keys written by older controller versions.
 The subnet is never guessed from namespace/default fallbacks, because
 writing a wrong VNI is worse than a missing one (nothing would correct it
@@ -117,8 +117,8 @@ restart cilium so it re-reads them for already-created endpoints. Every CNI
 ADD waits for `allocated=true`; when the persisted logical_switch resolves to
 a non-vlan OVN VPC subnet, it additionally waits for a valid annotation equal
 to `Subnet.Status.TunnelKey`. If backfill has not completed within the wait
-loop, ADD fails and kubelet retries. The cilium restart is still required for endpoints created before
-the backfill logic existed.
+loop, ADD fails and kubelet retries. The Cilium restart is still required for
+endpoints created before the backfill logic existed.
 
 ## Compatibility and rolling upgrade
 

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -93,8 +93,9 @@ Check the subnet status with:
 kubectl get subnet <name> -o jsonpath='{.status.tunnelKey}'
 ```
 
-A value of `0` means the key has not been synchronized. Check OVN SB
-reachability and whether the logical switch has a `Datapath_Binding` in SB.
+A value outside `1..16777215` is invalid and triggers fail-closed
+re-synchronization. Check OVN SB reachability and whether the logical switch
+has a `Datapath_Binding` in SB.
 Underlay/vlan subnets also use OVN logical switches and are subject to this
 gate.
 

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -153,6 +153,26 @@ provider naming.
 
 ## Known gaps (documented, not closed by code)
 
+- `Subnet.Status.TunnelKey` is not periodically compared with OVN SB. This is
+  intentional because a `Datapath_Binding` key is stable during the normal
+  lifecycle. After a destructive SB rebuild or an inconsistent DR restore,
+  northd may assign a different key while the persisted status still contains
+  an otherwise valid old value; `reconcileSubnetTunnelKey` will not re-read SB
+  until that status is invalidated. Recover every affected subnet as follows:
+
+  1. Clear its persisted key:
+
+     ```bash
+     kubectl patch subnet <name> --subresource=status --type=merge \
+       -p '{"status":{"tunnelKey":0}}'
+     ```
+
+  2. Restart kube-ovn-controller. InitIPAM detects affected pods; after subnet
+     workers re-read the new SB key, the deferred repair queue updates their
+     annotations. Wait for the startup repair Warning logs to complete.
+  3. Restart Cilium so existing endpoints reload the new VNI.
+
+  A controller restart without first invalidating status is insufficient.
 - Repair progress is observable via `pod_tunnel_key_repair_patch_total`
   (annotation patches that added, corrected or removed one or more tunnel_key
   annotations; a multi-NIC pod can be patched more than once) and

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -19,10 +19,11 @@ The guarantee is upheld by two flows:
 allocation (requeues, persisting no pod annotations) while the resolved
 subnet's tunnel key has not been synced from OVN SB
 (`Status.TunnelKey == 0`), and writes the tunnel_key annotation in the same
-atomic patch as `allocated=true`. The kube-ovn CNI server blocks until
-`allocated=true`, and Cilium (chained after kube-ovn, the primary CNI) only
-runs once kube-ovn's CNI ADD has succeeded, so by the time Cilium reads the
-pod, the annotation is present and non-zero.
+atomic patch as `allocated=true`. For a non-vlan OVN VPC subnet, the
+kube-ovn CNI server blocks until `allocated=true` and the pod annotation is
+a valid value equal to `Subnet.Status.TunnelKey`. Cilium (chained after
+kube-ovn, the primary CNI) only runs once kube-ovn's CNI ADD has succeeded,
+so by the time Cilium reads the pod, the annotation is correct.
 
 For a multi-NIC pod, an earlier loop iteration may already have created
 idempotent LSP/IP CR state before a later NIC hits the gate. This does not
@@ -32,9 +33,9 @@ the earlier objects again.
 
 Why flow 1 cannot produce a missing annotation: `reconcileAllocateSubnets`
 returns an error without persisting pod annotations while any requested
-OVN VPC subnet's tunnel key is not ready; `tunnel_key` and `allocated=true` are
-written in the same atomic patch; and the CNI server blocks on
-`allocated=true`. So under the current code a pod either carries the
+OVN VPC subnet's tunnel key is not ready; `tunnel_key` and `allocated=true`
+are written in the same atomic patch; and the CNI server verifies both before
+returning success. So under the current code a pod either carries the correct
 annotation or is still waiting at CNI ADD - a missing annotation therefore
 implies a legacy pod created before this guarantee existed, which is exactly
 the population flow 2 repairs.
@@ -103,17 +104,18 @@ TunnelKey value.
 ## Intended upgrade sequence
 
 Restart kube-ovn-controller first (flow 2 backfills the annotations), then
-restart cilium so it re-reads them for already-created endpoints. Note the
-CNI server only waits for `allocated=true`, so a CNI ADD for a legacy pod
-racing ahead of the repair proceeds without the annotation; if the ADD
-succeeds there is no kubelet retry, and the stale Cilium endpoint is
-corrected by the ordered cilium restart.
+restart cilium so it re-reads them for already-created endpoints. For every
+new CNI ADD on a non-vlan OVN VPC subnet, the CNI server waits for both
+`allocated=true` and a valid annotation equal to `Subnet.Status.TunnelKey`;
+if backfill has not completed within the wait loop, ADD fails and kubelet
+retries. The cilium restart is still required for endpoints created before
+the backfill logic existed.
 
 ## Known gaps (documented, not closed by code)
 
 - Repair progress is observable via `pod_tunnel_key_repair_patch_total`
-  (annotation patches that wrote one or more tunnel_key annotations; a
-  multi-NIC pod can be patched more than once) and
+  (annotation patches that added, corrected or removed one or more tunnel_key
+  annotations; a multi-NIC pod can be patched more than once) and
   `pod_tunnel_key_repair_skipped_total` (repairs skipped because the
   logical_switch subnet no longer exists) - see
   pkg/controller/tunnel_key_metrics.go.
@@ -130,8 +132,5 @@ corrected by the ordered cilium restart.
   because the pod usually cannot survive its subnet's deletion anyway.
 - The upgrade sequence above is operator discipline, not enforced by code:
   restarting cilium before the backfill completes leaves already-created
-  endpoints on the non-VPC scheme until the next cilium restart.
-- A CNI ADD racing the repair for a legacy pod is not closed by the CNI
-  server (it only waits for `allocated=true`) nor by a kubelet retry when
-  the ADD succeeds; the stale Cilium endpoint is corrected by the ordered
-  cilium restart in the upgrade sequence above.
+  endpoints on the non-VPC scheme until the next cilium restart. This affects
+  only endpoints that already exist; CNI ADD itself is fail-closed on the key.

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -2,7 +2,10 @@
 
 Every non-hostNetwork pod on a non-vlan OVN VPC subnet carries a valid
 `ovn.kubernetes.io/tunnel_key` (VNI) annotation by the time its network is
-configured (CNI ADD). VLAN/underlay and non-OVN subnets keep the default
+configured (CNI ADD). This includes both the default cluster-router VPC and
+custom VPCs. The exact scope predicate is
+`isOvnSubnet(subnet) && subnet.Spec.Vlan == ""`. VLAN/underlay and non-OVN
+subnets keep the default
 `status.tunnelKey=0` and do not carry the pod annotation. Cilium
 (native-vpc mode) keys pod identities by this annotation, so a missing
 annotation makes the pod fall back to the non-VPC scheme and collide with

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -58,7 +58,13 @@ the population flow 2 repairs.
 The repair enqueue runs only during the InitIPAM startup sweep. It is driven
 by persisted pod annotations (`podProvidersNeedingTunnelKeyRepair`) before
 NAD/default-subnet resolution, so every eligible legacy pod is enqueued once
-without a periodic task or a pod-update fallback.
+without a periodic task or a pod-update fallback. Detection and successful
+repair are logged at Warning level, including the instruction to restart
+Cilium after backfill so already-created endpoints reload the corrected VNI.
+
+This asynchronous repair is fallback recovery only; it is not part of normal
+pod allocation. Normal allocation writes IP/network, tunnel_key and
+`allocated=true` in one pod annotation patch.
 
 Repair is multi-NIC aware and driven by the per-provider annotations the
 allocation wrote (`allocated` + `logical_switch`). A provider is repaired

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -10,24 +10,29 @@ The guarantee is upheld by two flows:
 
 ## Flow 1: normal pod creation
 
-`reconcileAllocateSubnets` (pkg/controller/pod.go) refuses to allocate
-(requeues, persisting nothing) while the resolved subnet's tunnel key has
-not been synced from OVN SB (`Status.TunnelKey == 0`), and writes the
-tunnel_key annotation in the same atomic patch as `allocated=true`. The
-kube-ovn CNI server blocks until `allocated=true`, and Cilium (chained
-after kube-ovn, the primary CNI) only runs once kube-ovn's CNI ADD has
-succeeded, so by the time Cilium reads the pod, the annotation is present
-and non-zero.
+`reconcileAllocateSubnets` (pkg/controller/pod.go) refuses to complete the
+allocation (requeues, persisting no pod annotations) while the resolved
+subnet's tunnel key has not been synced from OVN SB
+(`Status.TunnelKey == 0`), and writes the tunnel_key annotation in the same
+atomic patch as `allocated=true`. The kube-ovn CNI server blocks until
+`allocated=true`, and Cilium (chained after kube-ovn, the primary CNI) only
+runs once kube-ovn's CNI ADD has succeeded, so by the time Cilium reads the
+pod, the annotation is present and non-zero.
 
-Why flow 1 cannot produce a missing annotation: the pod NIC (LSP) is
-created at a single point, `reconcileAllocateSubnets`, and that path
-returns an error (persisting nothing) while the tunnel key is not ready;
-`tunnel_key` and `allocated=true` are written in the same atomic patch;
-and the CNI server blocks on `allocated=true` before any NIC exists. So
-under the current code a pod either carries the annotation or is still
-waiting at CNI ADD - a missing annotation therefore implies a legacy pod
-created before this guarantee existed, which is exactly the population
-flow 2 repairs.
+For a multi-NIC pod, an earlier loop iteration may already have created
+idempotent LSP/IP CR state before a later NIC hits the gate. This does not
+weaken the CNI-visible guarantee: the pod annotation patch is committed only
+after every requested OVN NIC passes the gate, and retries safely reconcile
+the earlier objects again.
+
+Why flow 1 cannot produce a missing annotation: `reconcileAllocateSubnets`
+returns an error without persisting pod annotations while any requested
+OVN subnet's tunnel key is not ready; `tunnel_key` and `allocated=true` are
+written in the same atomic patch; and the CNI server blocks on
+`allocated=true`. So under the current code a pod either carries the
+annotation or is still waiting at CNI ADD - a missing annotation therefore
+implies a legacy pod created before this guarantee existed, which is exactly
+the population flow 2 repairs.
 
 ## Flow 2: kube-ovn-controller restart / legacy pods
 
@@ -66,6 +71,30 @@ afterwards); a `logical_switch` that does not resolve is counted by
 not all-or-nothing: ready providers are patched in one call even when
 another provider's subnet key is still 0 (the handler then returns an
 error to requeue for the remainder).
+
+## Failure mode and diagnosis
+
+The allocation gate is intentionally fail-closed. If an OVN subnet's tunnel
+key cannot be observed (for example, OVN SB is unreachable or northd has not
+created the logical switch's `Datapath_Binding`), new pods on that subnet are
+not allocated with a guessed or zero VNI:
+
+- the pod remains in `ContainerCreating`;
+- kube-ovn CNI waits for `allocated=true`, fails after its wait loop, and the
+  kubelet retries CNI ADD;
+- the pod receives an `AcquireAddressFailed` event containing
+  `subnet <name> tunnel key not observed on allocation`.
+
+Check the subnet status with:
+
+```bash
+kubectl get subnet <name> -o jsonpath='{.status.tunnelKey}'
+```
+
+A value of `0` means the key has not been synchronized. Check OVN SB
+reachability and whether the logical switch has a `Datapath_Binding` in SB.
+Underlay/vlan subnets also use OVN logical switches and are subject to this
+gate.
 
 ## Intended upgrade sequence
 

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -58,9 +58,13 @@ the population flow 2 repairs.
 The repair enqueue runs only during the InitIPAM startup sweep. It is driven
 by persisted pod annotations (`podProvidersNeedingTunnelKeyRepair`) before
 NAD/default-subnet resolution, so every eligible legacy pod is enqueued once
-without a periodic task or a pod-update fallback. Detection and successful
-repair are logged at Warning level, including the instruction to restart
-Cilium after backfill so already-created endpoints reload the corrected VNI.
+without a periodic task or a pod-update fallback. The queue is necessarily
+asynchronous because InitIPAM runs before `startWorkers`; a missing subnet key
+may require the subnet worker, so waiting synchronously in InitIPAM would
+block the worker that produces it. Repair workers start afterward and retry
+with rate limiting. Detection and successful repair are logged at Warning
+level, including the instruction to restart Cilium after backfill so
+already-created endpoints reload the corrected VNI.
 
 This asynchronous repair is fallback recovery only; it is not part of normal
 pod allocation. Normal allocation writes IP/network, tunnel_key and
@@ -110,8 +114,9 @@ TunnelKey value.
 
 Restart kube-ovn-controller first (flow 2 backfills the annotations), then
 restart cilium so it re-reads them for already-created endpoints. For every
-new CNI ADD on a non-vlan OVN VPC subnet, the CNI server waits for both
-`allocated=true` and a valid annotation equal to `Subnet.Status.TunnelKey`;
+new CNI ADD on a non-vlan OVN VPC subnet, the CNI server waits for an OVN
+logical_switch, `allocated=true`, and a valid annotation equal to
+`Subnet.Status.TunnelKey`;
 if backfill has not completed within the wait loop, ADD fails and kubelet
 retries. The cilium restart is still required for endpoints created before
 the backfill logic existed.

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -1,0 +1,88 @@
+# tunnel_key (VNI) annotation guarantee
+
+Every non-hostNetwork pod on an OVN subnet carries a non-zero
+`ovn.kubernetes.io/tunnel_key` (VNI) annotation by the time its network is
+configured (CNI ADD). Cilium (native-vpc mode) keys pod identities by this
+annotation, so a missing annotation makes the pod fall back to the non-VPC
+scheme and collide with overlapping VPC subnets.
+
+The guarantee is upheld by two flows:
+
+## Flow 1: normal pod creation
+
+`reconcileAllocateSubnets` (pkg/controller/pod.go) refuses to allocate
+(requeues, persisting nothing) while the resolved subnet's tunnel key has
+not been synced from OVN SB (`Status.TunnelKey == 0`), and writes the
+tunnel_key annotation in the same atomic patch as `allocated=true`. The
+kube-ovn CNI server blocks until `allocated=true`, and Cilium (chained
+after kube-ovn, the primary CNI) only runs once kube-ovn's CNI ADD has
+succeeded, so by the time Cilium reads the pod, the annotation is present
+and non-zero.
+
+Why flow 1 cannot produce a missing annotation: the pod NIC (LSP) is
+created at a single point, `reconcileAllocateSubnets`, and that path
+returns an error (persisting nothing) while the tunnel key is not ready;
+`tunnel_key` and `allocated=true` are written in the same atomic patch;
+and the CNI server blocks on `allocated=true` before any NIC exists. So
+under the current code a pod either carries the annotation or is still
+waiting at CNI ADD - a missing annotation therefore implies a legacy pod
+created before this guarantee existed, which is exactly the population
+flow 2 repairs.
+
+## Flow 2: kube-ovn-controller restart / legacy pods
+
+- Pods created after the restart follow flow 1 (the gate lives in the
+  allocation path and is unrelated to restarts).
+- Pods that already carry the annotation keep it (persisted in etcd).
+- Legacy pods allocated before the subnet tunnel key was synced (or before
+  this code existed) are missing the annotation. On startup `InitIPAM`
+  enqueues them into the dedicated `repairTunnelKeyQueue`
+  (`enqueuePodTunnelKeyRepair`); the repair worker
+  (`handleRepairTunnelKey`) patches them from `subnet.Status.TunnelKey`,
+  retrying with unbounded backoff until the key becomes available (subnet
+  reconcile may still be syncing it).
+
+Enqueue is not one-shot: the pod reconcile path (`handleAddOrUpdatePod`)
+and a post-start resync (`resyncPodTunnelKey`, bounded to a backfill
+window of `tunnelKeyResyncWindow`) also enqueue repairs, so a pod the
+startup sweep missed (e.g. its NAD or default subnet could not be resolved
+at that moment) heals on the next pod update event, or on a resync tick
+within the window, instead of requiring another controller restart.
+
+Repair is multi-NIC aware and driven purely by the per-provider annotations
+the allocation wrote (`allocated` + `logical_switch`): every OVN subnet has
+its own `tunnel_key` annotation. A provider is repaired only if it is
+marked allocated and its `logical_switch` annotation resolves to an OVN
+subnet; the subnet is never guessed from namespace/default fallbacks,
+because writing a wrong VNI is worse than a missing one (nothing would
+correct it afterwards). Progress is not all-or-nothing: ready providers are
+patched in one call even when another provider's subnet key is still 0 (the
+handler then returns an error to requeue for the remainder).
+
+## Intended upgrade sequence
+
+Restart kube-ovn-controller first (flow 2 backfills the annotations), then
+restart cilium so it re-reads them for already-created endpoints. Note the
+CNI server only waits for `allocated=true`, so a CNI ADD for a legacy pod
+racing ahead of the repair proceeds without the annotation; if the ADD
+succeeds there is no kubelet retry, and the stale Cilium endpoint is
+corrected by the ordered cilium restart.
+
+## Known gaps (documented, not closed by code)
+
+- Repair progress is observable via `pod_tunnel_key_missing` (gap size at
+  the last resync during the post-start backfill window),
+  `pod_tunnel_key_repair_total` and `pod_tunnel_key_repair_skipped_total`
+  (see pkg/controller/tunnel_key_metrics.go).
+- Repair keying is per `podNet.ProviderName` (the `*.kubernetes.io/*`
+  annotation templates). Cilium currently only recognizes the primary NIC
+  (default provider, `ovn.kubernetes.io/*` annotations), so a mismatch on
+  a multus secondary NIC would be harmless today; it only matters if
+  Cilium starts keying secondary NICs.
+- The upgrade sequence above is operator discipline, not enforced by code:
+  restarting cilium before the backfill completes leaves already-created
+  endpoints on the non-VPC scheme until the next cilium restart.
+- A CNI ADD racing the repair for a legacy pod is not closed by the CNI
+  server (it only waits for `allocated=true`) nor by a kubelet retry when
+  the ADD succeeds; the stale Cilium endpoint is corrected by the ordered
+  cilium restart in the upgrade sequence above.

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -1,10 +1,12 @@
 # tunnel_key (VNI) annotation guarantee
 
-Every non-hostNetwork pod on an OVN subnet carries a non-zero
+Every non-hostNetwork pod on a non-vlan OVN VPC subnet carries a valid
 `ovn.kubernetes.io/tunnel_key` (VNI) annotation by the time its network is
-configured (CNI ADD). Cilium (native-vpc mode) keys pod identities by this
-annotation, so a missing annotation makes the pod fall back to the non-VPC
-scheme and collide with overlapping VPC subnets.
+configured (CNI ADD). VLAN/underlay and non-OVN subnets keep the default
+`status.tunnelKey=0` and do not carry the pod annotation. Cilium
+(native-vpc mode) keys pod identities by this annotation, so a missing
+annotation makes the pod fall back to the non-VPC scheme and collide with
+overlapping VPC subnets.
 
 The guarantee is upheld by two flows:
 
@@ -22,12 +24,12 @@ pod, the annotation is present and non-zero.
 For a multi-NIC pod, an earlier loop iteration may already have created
 idempotent LSP/IP CR state before a later NIC hits the gate. This does not
 weaken the CNI-visible guarantee: the pod annotation patch is committed only
-after every requested OVN NIC passes the gate, and retries safely reconcile
+after every requested OVN VPC NIC passes the gate, and retries safely reconcile
 the earlier objects again.
 
 Why flow 1 cannot produce a missing annotation: `reconcileAllocateSubnets`
 returns an error without persisting pod annotations while any requested
-OVN subnet's tunnel key is not ready; `tunnel_key` and `allocated=true` are
+OVN VPC subnet's tunnel key is not ready; `tunnel_key` and `allocated=true` are
 written in the same atomic patch; and the CNI server blocks on
 `allocated=true`. So under the current code a pod either carries the
 annotation or is still waiting at CNI ADD - a missing annotation therefore
@@ -49,23 +51,19 @@ the population flow 2 repairs.
   an aggregate 10-qps token bucket until the key becomes available (subnet
   reconcile may still be syncing it).
 
-Enqueue is not one-shot: the enqueue is annotation-driven
-(`podProvidersMissingTunnelKey`), so the startup sweep cannot skip a pod
+Enqueue is not one-shot: reconciliation is annotation-driven
+(`podProvidersNeedingTunnelKeyRepair`), so the startup sweep cannot skip a pod
 because its NAD or default subnet could not be resolved at that moment; the
 pod reconcile path (`handleAddOrUpdatePod`) re-enqueues on any later update
 event.
 
-Repair is multi-NIC aware and driven purely by the per-provider annotations
-the allocation wrote (`allocated` + `logical_switch`): every OVN subnet has
-its own valid `tunnel_key` annotation. A provider is repaired if its key is
-missing, non-numeric or outside `1..16777215`, and only if it is marked
-allocated and its `logical_switch` annotation resolves to an OVN subnet. An allocated provider with an empty `logical_switch` is a NIC whose
-subnet provider is not ovn (kube-ovn acts as IPAM only, another CNI
-configures the NIC) and is skipped silently - the OVN allocation path
-always writes `logical_switch`, so the empty case reliably means no
-tunnel_key is ever written. Note that vlan/underlay subnets keep provider
-`ovn`: they are part of this mechanism (the allocation gate also applies,
-so underlay pods wait for the tunnel key before IP allocation).
+Repair is multi-NIC aware and driven by the per-provider annotations the
+allocation wrote (`allocated` + `logical_switch`). A provider is repaired
+only when its logical switch resolves to a non-vlan OVN VPC subnet and its
+key is missing, invalid or different from `subnet.Status.TunnelKey`.
+Providers managed by another CNI have no `logical_switch`; OVN vlan/underlay subnets have one but
+are filtered by `isOvnVpcSubnet`. Both keep no pod tunnel_key annotation;
+startup repair removes stale keys written by older controller versions.
 The subnet is never guessed from namespace/default fallbacks, because
 writing a wrong VNI is worse than a missing one (nothing would correct it
 afterwards); a `logical_switch` that does not resolve is counted by
@@ -76,10 +74,10 @@ error to requeue for the remainder).
 
 ## Failure mode and diagnosis
 
-The allocation gate is intentionally fail-closed. If an OVN subnet's tunnel
-key cannot be observed (for example, OVN SB is unreachable or northd has not
-created the logical switch's `Datapath_Binding`), new pods on that subnet are
-not allocated with a guessed or zero VNI:
+The allocation gate is intentionally fail-closed. If a non-vlan OVN VPC
+subnet's tunnel key cannot be observed (for example, OVN SB is unreachable
+or northd has not created the logical switch's `Datapath_Binding`), new
+pods on that subnet are not allocated with a guessed or zero VNI:
 
 - the pod remains in `ContainerCreating`;
 - kube-ovn CNI waits for `allocated=true`, fails after its wait loop, and the
@@ -96,8 +94,8 @@ kubectl get subnet <name> -o jsonpath='{.status.tunnelKey}'
 A value outside `1..16777215` is invalid and triggers fail-closed
 re-synchronization. Check OVN SB reachability and whether the logical switch
 has a `Datapath_Binding` in SB.
-Underlay/vlan subnets also use OVN logical switches and are subject to this
-gate.
+VLAN/underlay subnets are not subject to this gate and keep the default
+TunnelKey value.
 
 ## Intended upgrade sequence
 

--- a/docs/tunnel-key-annotation-guarantee.md
+++ b/docs/tunnel-key-annotation-guarantee.md
@@ -121,6 +121,35 @@ if backfill has not completed within the wait loop, ADD fails and kubelet
 retries. The cilium restart is still required for endpoints created before
 the backfill logic existed.
 
+## Compatibility and rolling upgrade
+
+The Subnet API is unchanged: `status.tunnelKey` remains an optional integer,
+and pod annotation keys keep their existing provider-based format. Normal
+non-vlan OVN VPC allocation remains compatible with controllers that already
+wrote the annotation atomically.
+
+Two behavior changes are intentional:
+
+- VLAN/underlay and non-OVN subnets now converge to
+  `status.tunnelKey=0` and no pod tunnel_key annotation. Older controller
+  versions may have populated those values even though native-vpc identity
+  does not consume them; startup reconciliation removes those stale values.
+- The new daemon fails CNI ADD for an OVN VPC provider until logical_switch,
+  `allocated=true`, and the matching tunnel_key are visible. This converts a
+  previously possible legacy race into a retryable CNI failure.
+
+For rolling upgrades, restart/upgrade kube-ovn-controller first, wait for the
+startup repair warnings to complete, then restart/upgrade kube-ovn-daemon and
+Cilium. An old daemon does not enforce the new CNI key gate; a new daemon is
+compatible with a controller that already performs the atomic VPC annotation
+patch. Rollback is safe: an older controller may repopulate VLAN tunnel-key
+status, and a subsequent new-controller startup cleans it again.
+
+Non-primary-CNI remains compatible: non-vlan OVN attachment providers use the
+same per-provider annotation contract. IPAM-only attachments remain compatible
+when they use a non-OVN provider as designed; such providers legitimately have
+no OVN logical_switch and bypass the VPC key gate.
+
 ## Known gaps (documented, not closed by code)
 
 - Repair progress is observable via `pod_tunnel_key_repair_patch_total`

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-community/pro-bing v0.8.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/puzpuzpuz/xsync/v4 v4.4.0
 	github.com/scylladb/go-set v1.0.2
 	github.com/sirupsen/logrus v1.9.4
@@ -139,7 +140,6 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
@@ -163,7 +163,6 @@ require (
 	github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 // indirect
 	github.com/projectcalico/libcalico-go v0.0.0-20190305235709-3d935c3b8b86 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.83.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect

--- a/pkg/apis/kubeovn/v1/subnet.go
+++ b/pkg/apis/kubeovn/v1/subnet.go
@@ -143,8 +143,8 @@ type SubnetStatus struct {
 	NatOutgoingPolicyRules []NatOutgoingPolicyRuleStatus `json:"natOutgoingPolicyRules"`
 	McastQuerierIP         string                        `json:"mcastQuerierIP"`
 	McastQuerierMAC        string                        `json:"mcastQuerierMAC"`
-	// TunnelKey is the OVN logical switch tunnel_key (VNI) read from the SB Datapath_Binding.
-	// It is synced for every OVN subnet before the subnet is marked Ready, and stays 0 for
+	// TunnelKey is the OVN logical switch tunnel_key (VNI) used by non-vlan OVN VPC subnets.
+	// It is synced before those subnets are marked Ready and stays 0 for vlan/underlay and
 	// non-OVN subnets. The omitempty tag is required: patchSubnetStatus serializes the whole
 	// status, so without it a 0 value here would overwrite an already-synced tunnel_key.
 	TunnelKey int `json:"tunnelKey,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -99,12 +99,13 @@ type Controller struct {
 	// the subnet tunnel key was synced (or before this code existed) keep a
 	// missing annotation forever because the allocation path never re-patches
 	// already-allocated pods. The queue is fed by the init flow on controller
-	// start (see enqueuePodTunnelKeyRepair, called from InitIPAM), keeping the
-	// repair out of the main pod reconcile path and out of the subnet
-	// reconcile path. Cilium (native-vpc mode) keys pod identities by this
-	// annotation, so the intended upgrade sequence is: restart
-	// kube-ovn-controller first (this queue backfills the annotations), then
-	// restart cilium, which picks them up.
+	// start and by the pod reconcile path (see enqueuePodTunnelKeyRepair),
+	// both annotation-driven so the enqueue cannot be skipped by a network
+	// resolution failure; the handler runs on dedicated workers, serialized
+	// with the pod reconcile path via podKeyMutex. Cilium (native-vpc mode)
+	// keys pod identities by this annotation, so the intended upgrade
+	// sequence is: restart kube-ovn-controller first (this queue backfills
+	// the annotations), then restart cilium, which picks them up.
 	repairTunnelKeyQueue   workqueue.TypedRateLimitingInterface[string]
 	deletingPodObjMap      *xsync.Map[string, *corev1.Pod]
 	deletingNodeObjMap     *xsync.Map[string, *corev1.Node]
@@ -564,10 +565,14 @@ func Run(ctx context.Context, config *Configuration) {
 		providerNetworksLister: providerNetworkInformer.Lister(),
 		providerNetworkSynced:  providerNetworkInformer.Informer().HasSynced,
 
-		podsLister:           podInformer.Lister(),
-		podsSynced:           podInformer.Informer().HasSynced,
-		addOrUpdatePodQueue:  newTypedRateLimitingQueue[string]("AddOrUpdatePod", nil),
-		repairTunnelKeyQueue: newTypedRateLimitingQueue[string]("RepairTunnelKey", nil),
+		podsLister:          podInformer.Lister(),
+		podsSynced:          podInformer.Informer().HasSynced,
+		addOrUpdatePodQueue: newTypedRateLimitingQueue[string]("AddOrUpdatePod", nil),
+		// Repair retries start at 1s instead of the default 5ms: a subnet
+		// whose tunnel key stays 0 makes the queued pods requeue in a tight
+		// loop, and a 5ms base would hammer the shared podKeyMutex buckets.
+		repairTunnelKeyQueue: newTypedRateLimitingQueue[string]("RepairTunnelKey",
+			workqueue.NewTypedItemExponentialFailureRateLimiter[string](time.Second, time.Minute)),
 		deletePodQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
@@ -1466,11 +1471,6 @@ func (c *Controller) startWorkers(ctx context.Context) {
 	go wait.Until(func() {
 		c.resyncVpcNatConfig()
 	}, time.Second, ctx.Done())
-
-	// Periodic safety net for the tunnel_key guarantee: re-enqueues repairs
-	// for pods the InitIPAM startup sweep missed (see resyncPodTunnelKey).
-	// Single instance, bounded to the post-start backfill window.
-	go c.resyncPodTunnelKey(ctx)
 
 	if c.config.GCInterval != 0 {
 		go wait.Until(func() {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -93,9 +93,10 @@ type Controller struct {
 	addOrUpdatePodQueue workqueue.TypedRateLimitingInterface[string]
 	deletePodQueue      workqueue.TypedRateLimitingInterface[string]
 	// repairTunnelKeyQueue reconciles persisted per-provider tunnel_key
-	// annotations during the InitIPAM startup sweep. Its workers serialize with
-	// normal pod reconciliation through podKeyMutex. See
-	// docs/tunnel-key-annotation-guarantee.md for the full invariant.
+	// annotations discovered by InitIPAM. It must be asynchronous: InitIPAM runs
+	// before subnet workers that may still need to produce Status.TunnelKey.
+	// Repair workers start afterward and serialize with pod reconciliation via
+	// podKeyMutex. See docs/tunnel-key-annotation-guarantee.md.
 	repairTunnelKeyQueue   workqueue.TypedRateLimitingInterface[string]
 	deletingPodObjMap      *xsync.Map[string, *corev1.Pod]
 	deletingNodeObjMap     *xsync.Map[string, *corev1.Node]

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -92,10 +92,10 @@ type Controller struct {
 	podsSynced          cache.InformerSynced
 	addOrUpdatePodQueue workqueue.TypedRateLimitingInterface[string]
 	deletePodQueue      workqueue.TypedRateLimitingInterface[string]
-	// repairTunnelKeyQueue reconciles per-provider tunnel_key annotations. It
-	// is fed by InitIPAM and pod updates using only persisted annotations; its
-	// workers serialize with normal pod reconciliation through podKeyMutex.
-	// See docs/tunnel-key-annotation-guarantee.md for the full invariant.
+	// repairTunnelKeyQueue reconciles persisted per-provider tunnel_key
+	// annotations during the InitIPAM startup sweep. Its workers serialize with
+	// normal pod reconciliation through podKeyMutex. See
+	// docs/tunnel-key-annotation-guarantee.md for the full invariant.
 	repairTunnelKeyQueue   workqueue.TypedRateLimitingInterface[string]
 	deletingPodObjMap      *xsync.Map[string, *corev1.Pod]
 	deletingNodeObjMap     *xsync.Map[string, *corev1.Node]

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -92,20 +92,10 @@ type Controller struct {
 	podsSynced          cache.InformerSynced
 	addOrUpdatePodQueue workqueue.TypedRateLimitingInterface[string]
 	deletePodQueue      workqueue.TypedRateLimitingInterface[string]
-	// repairTunnelKeyQueue is a dedicated queue for patching the tunnel_key
-	// (VNI) annotation onto pods that are missing it, closing the
-	// "must-have tunnel_key" guarantee after a controller restart (see
-	// docs/tunnel-key-annotation-guarantee.md): pods allocated before
-	// the subnet tunnel key was synced (or before this code existed) keep a
-	// missing annotation forever because the allocation path never re-patches
-	// already-allocated pods. The queue is fed by the init flow on controller
-	// start and by the pod reconcile path (see enqueuePodTunnelKeyRepair),
-	// both annotation-driven so the enqueue cannot be skipped by a network
-	// resolution failure; the handler runs on dedicated workers, serialized
-	// with the pod reconcile path via podKeyMutex. Cilium (native-vpc mode)
-	// keys pod identities by this annotation, so the intended upgrade
-	// sequence is: restart kube-ovn-controller first (this queue backfills
-	// the annotations), then restart cilium, which picks them up.
+	// repairTunnelKeyQueue reconciles per-provider tunnel_key annotations. It
+	// is fed by InitIPAM and pod updates using only persisted annotations; its
+	// workers serialize with normal pod reconciliation through podKeyMutex.
+	// See docs/tunnel-key-annotation-guarantee.md for the full invariant.
 	repairTunnelKeyQueue   workqueue.TypedRateLimitingInterface[string]
 	deletingPodObjMap      *xsync.Map[string, *corev1.Pod]
 	deletingNodeObjMap     *xsync.Map[string, *corev1.Node]

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -92,11 +92,10 @@ type Controller struct {
 	podsSynced          cache.InformerSynced
 	addOrUpdatePodQueue workqueue.TypedRateLimitingInterface[string]
 	deletePodQueue      workqueue.TypedRateLimitingInterface[string]
-	// repairTunnelKeyQueue reconciles persisted per-provider tunnel_key
-	// annotations discovered by InitIPAM. It must be asynchronous: InitIPAM runs
-	// before subnet workers that may still need to produce Status.TunnelKey.
-	// Repair workers start afterward and serialize with pod reconciliation via
-	// podKeyMutex. See docs/tunnel-key-annotation-guarantee.md.
+	// repairTunnelKeyQueue contains only startup repairs that could not finish
+	// synchronously in InitIPAM because a subnet worker must still produce the
+	// key or a transient error needs retry. Workers start afterward and serialize
+	// with pod reconciliation via podKeyMutex. See the guarantee document.
 	repairTunnelKeyQueue   workqueue.TypedRateLimitingInterface[string]
 	deletingPodObjMap      *xsync.Map[string, *corev1.Pod]
 	deletingNodeObjMap     *xsync.Map[string, *corev1.Node]

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -568,11 +568,15 @@ func Run(ctx context.Context, config *Configuration) {
 		podsLister:          podInformer.Lister(),
 		podsSynced:          podInformer.Informer().HasSynced,
 		addOrUpdatePodQueue: newTypedRateLimitingQueue[string]("AddOrUpdatePod", nil),
-		// Repair retries start at 1s instead of the default 5ms: a subnet
-		// whose tunnel key stays 0 makes the queued pods requeue in a tight
-		// loop, and a 5ms base would hammer the shared podKeyMutex buckets.
+		// Repair retries start at 1s instead of the default 5ms, and a global
+		// token bucket caps the aggregate requeue rate: a subnet whose tunnel
+		// key stays 0 makes the queued pods requeue in a loop, and a 5ms base
+		// with no bucket would hammer the shared podKeyMutex buckets.
 		repairTunnelKeyQueue: newTypedRateLimitingQueue[string]("RepairTunnelKey",
-			workqueue.NewTypedItemExponentialFailureRateLimiter[string](time.Second, time.Minute)),
+			workqueue.NewTypedMaxOfRateLimiter[string](
+				workqueue.NewTypedItemExponentialFailureRateLimiter[string](time.Second, time.Minute),
+				&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+			)),
 		deletePodQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -94,8 +94,8 @@ type Controller struct {
 	deletePodQueue      workqueue.TypedRateLimitingInterface[string]
 	// repairTunnelKeyQueue is a dedicated queue for patching the tunnel_key
 	// (VNI) annotation onto pods that are missing it, closing the
-	// "must-have tunnel_key" guarantee after a controller restart (see the
-	// Guarantee comment on tunnelKeyNotReady in pod.go): pods allocated before
+	// "must-have tunnel_key" guarantee after a controller restart (see
+	// docs/tunnel-key-annotation-guarantee.md): pods allocated before
 	// the subnet tunnel key was synced (or before this code existed) keep a
 	// missing annotation forever because the allocation path never re-patches
 	// already-allocated pods. The queue is fed by the init flow on controller

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1425,9 +1425,6 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		// processed by one worker at a time), which keeps the startup backfill
 		// fast on large clusters.
 		go wait.Until(runWorker("repair tunnel key", c.repairTunnelKeyQueue, c.handleRepairTunnelKey), time.Second, ctx.Done())
-		// Periodic safety net for the tunnel_key guarantee: re-enqueues repairs
-		// for pods the InitIPAM startup sweep missed (see resyncPodTunnelKey).
-		go c.resyncPodTunnelKey(ctx)
 
 		go wait.Until(runWorker("delete subnet", c.deleteSubnetQueue, c.handleDeleteSubnet), time.Second, ctx.Done())
 		go wait.Until(runWorker("delete ippool", c.deleteIPPoolQueue, c.handleDeleteIPPool), time.Second, ctx.Done())
@@ -1469,6 +1466,11 @@ func (c *Controller) startWorkers(ctx context.Context) {
 	go wait.Until(func() {
 		c.resyncVpcNatConfig()
 	}, time.Second, ctx.Done())
+
+	// Periodic safety net for the tunnel_key guarantee: re-enqueues repairs
+	// for pods the InitIPAM startup sweep missed (see resyncPodTunnelKey).
+	// Single instance: the full-pod scan must not be multiplied by WorkerNum.
+	go c.resyncPodTunnelKey(ctx)
 
 	if c.config.GCInterval != 0 {
 		go wait.Until(func() {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1469,7 +1469,7 @@ func (c *Controller) startWorkers(ctx context.Context) {
 
 	// Periodic safety net for the tunnel_key guarantee: re-enqueues repairs
 	// for pods the InitIPAM startup sweep missed (see resyncPodTunnelKey).
-	// Single instance: the full-pod scan must not be multiplied by WorkerNum.
+	// Single instance, bounded to the post-start backfill window.
 	go c.resyncPodTunnelKey(ctx)
 
 	if c.config.GCInterval != 0 {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -88,10 +88,24 @@ type Controller struct {
 	// ExternalGatewayType define external gateway type, centralized
 	ExternalGatewayType string
 
-	podsLister             v1.PodLister
-	podsSynced             cache.InformerSynced
-	addOrUpdatePodQueue    workqueue.TypedRateLimitingInterface[string]
-	deletePodQueue         workqueue.TypedRateLimitingInterface[string]
+	podsLister          v1.PodLister
+	podsSynced          cache.InformerSynced
+	addOrUpdatePodQueue workqueue.TypedRateLimitingInterface[string]
+	deletePodQueue      workqueue.TypedRateLimitingInterface[string]
+	// repairTunnelKeyQueue is a dedicated queue for patching the tunnel_key
+	// (VNI) annotation onto pods that are missing it, closing the
+	// "must-have tunnel_key" guarantee after a controller restart (see the
+	// Guarantee comment on tunnelKeyNotReady in pod.go): pods allocated before
+	// the subnet tunnel key was synced (or before this code existed) keep a
+	// missing annotation forever because the allocation path never re-patches
+	// already-allocated pods. The queue is fed by the init flow on controller
+	// start (see enqueuePodTunnelKeyRepair, called from InitIPAM), keeping the
+	// repair out of the main pod reconcile path and out of the subnet
+	// reconcile path. Cilium (native-vpc mode) keys pod identities by this
+	// annotation, so the intended upgrade sequence is: restart
+	// kube-ovn-controller first (this queue backfills the annotations), then
+	// restart cilium, which picks them up.
+	repairTunnelKeyQueue   workqueue.TypedRateLimitingInterface[string]
 	deletingPodObjMap      *xsync.Map[string, *corev1.Pod]
 	deletingNodeObjMap     *xsync.Map[string, *corev1.Node]
 	updatePodSecurityQueue workqueue.TypedRateLimitingInterface[string]
@@ -550,9 +564,10 @@ func Run(ctx context.Context, config *Configuration) {
 		providerNetworksLister: providerNetworkInformer.Lister(),
 		providerNetworkSynced:  providerNetworkInformer.Informer().HasSynced,
 
-		podsLister:          podInformer.Lister(),
-		podsSynced:          podInformer.Informer().HasSynced,
-		addOrUpdatePodQueue: newTypedRateLimitingQueue[string]("AddOrUpdatePod", nil),
+		podsLister:           podInformer.Lister(),
+		podsSynced:           podInformer.Informer().HasSynced,
+		addOrUpdatePodQueue:  newTypedRateLimitingQueue[string]("AddOrUpdatePod", nil),
+		repairTunnelKeyQueue: newTypedRateLimitingQueue[string]("RepairTunnelKey", nil),
 		deletePodQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
@@ -1180,6 +1195,7 @@ func (c *Controller) shutdown() {
 
 	c.addOrUpdatePodQueue.ShutDown()
 	c.deletePodQueue.ShutDown()
+	c.repairTunnelKeyQueue.ShutDown()
 	c.updatePodSecurityQueue.ShutDown()
 
 	c.addNamespaceQueue.ShutDown()
@@ -1404,6 +1420,11 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		go wait.Until(runWorker("delete pod", c.deletePodQueue, c.handleDeletePod), time.Second, ctx.Done())
 		go wait.Until(runWorker("add/update pod", c.addOrUpdatePodQueue, c.handleAddOrUpdatePod), time.Second, ctx.Done())
 		go wait.Until(runWorker("update pod security", c.updatePodSecurityQueue, c.handleUpdatePodSecurity), time.Second, ctx.Done())
+		// tunnel_key repairs are idempotent merge-patches; multiple workers only
+		// parallelize across different pods (workqueue guarantees a key is
+		// processed by one worker at a time), which keeps the startup backfill
+		// fast on large clusters.
+		go wait.Until(runWorker("repair tunnel key", c.repairTunnelKeyQueue, c.handleRepairTunnelKey), time.Second, ctx.Done())
 
 		go wait.Until(runWorker("delete subnet", c.deleteSubnetQueue, c.handleDeleteSubnet), time.Second, ctx.Done())
 		go wait.Until(runWorker("delete ippool", c.deleteIPPoolQueue, c.handleDeleteIPPool), time.Second, ctx.Done())

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1425,6 +1425,9 @@ func (c *Controller) startWorkers(ctx context.Context) {
 		// processed by one worker at a time), which keeps the startup backfill
 		// fast on large clusters.
 		go wait.Until(runWorker("repair tunnel key", c.repairTunnelKeyQueue, c.handleRepairTunnelKey), time.Second, ctx.Done())
+		// Periodic safety net for the tunnel_key guarantee: re-enqueues repairs
+		// for pods the InitIPAM startup sweep missed (see resyncPodTunnelKey).
+		go c.resyncPodTunnelKey(ctx)
 
 		go wait.Until(runWorker("delete subnet", c.deleteSubnetQueue, c.handleDeleteSubnet), time.Second, ctx.Done())
 		go wait.Until(runWorker("delete ippool", c.deleteIPPoolQueue, c.handleDeleteIPPool), time.Second, ctx.Done())

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -200,6 +200,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		recorder:                record.NewFakeRecorder(100),
 		subnetKeyMutex:          keymutex.NewHashed(0),
 		addOrUpdateSubnetQueue:  newTypedRateLimitingQueue[string]("AddOrUpdateSubnet", nil),
+		repairTunnelKeyQueue:    newTypedRateLimitingQueue[string]("RepairTunnelKey", nil),
 		syncVirtualPortsQueue:   newTypedRateLimitingQueue[string]("SyncVirtualPort", nil),
 		updateSubnetStatusQueue: newTypedRateLimitingQueue[string]("UpdateSubnetStatus", nil),
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -199,6 +199,7 @@ func newFakeControllerWithOptions(t *testing.T, opts *FakeControllerOptions) (*f
 		ipam:                    ovnipam.NewIPAM(),
 		recorder:                record.NewFakeRecorder(100),
 		subnetKeyMutex:          keymutex.NewHashed(0),
+		podKeyMutex:             keymutex.NewHashed(0),
 		addOrUpdateSubnetQueue:  newTypedRateLimitingQueue[string]("AddOrUpdateSubnet", nil),
 		repairTunnelKeyQueue:    newTypedRateLimitingQueue[string]("RepairTunnelKey", nil),
 		syncVirtualPortsQueue:   newTypedRateLimitingQueue[string]("SyncVirtualPort", nil),

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -472,6 +472,15 @@ func (c *Controller) InitIPAM() error {
 				// Append ExternalIds is added in v1.7, used for upgrading from v1.6.3. It should be deleted now since v1.7 is not used anymore.
 			}
 		}
+
+		// Enqueue OVN pods missing the tunnel_key (VNI) annotation into the
+		// dedicated repair queue. Cilium (native-vpc mode) keys pod identities
+		// by this annotation; pods allocated before the subnet tunnel key was
+		// synced from OVN SB (or before this code existed) keep a missing
+		// annotation forever. Reuses the pod-level filtering (hostNetwork,
+		// alive) done above. The repair handler retries until the subnet key
+		// becomes available, so pods are enqueued even if it is still 0.
+		c.enqueuePodTunnelKeyRepair(pod, podNets)
 	}
 
 	klog.Infof("Init IPAM from vip CR")

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -442,11 +442,14 @@ func (c *Controller) InitIPAM() error {
 		}
 
 		// Startup fallback only: normal allocation atomically writes IP/network,
-		// tunnel_key and allocated annotations. Repair synchronously when status
-		// is ready; only an unavailable key or transient failure is queued because
-		// InitIPAM runs before the subnet/repair workers needed to finish it.
-		// Detection logs a Warning requiring a Cilium restart for existing endpoints.
-		c.repairPodTunnelKeyOnStartup(pod)
+		// tunnel_key and allocated annotations. Enter recovery only when persisted
+		// annotations are missing, invalid or inconsistent with subnet policy.
+		// Repair synchronously when status is ready; only an unavailable key or
+		// transient failure is queued because InitIPAM runs before the workers
+		// needed to finish it.
+		if providers := c.podProvidersNeedingTunnelKeyRepair(pod); len(providers) != 0 {
+			c.repairPodTunnelKeyOnStartup(pod, providers)
+		}
 
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -442,19 +442,17 @@ func (c *Controller) InitIPAM() error {
 		}
 
 		// Startup fallback only: normal allocation atomically writes IP/network,
-		// tunnel_key and allocated annotations. The queue is necessarily
-		// asynchronous because InitIPAM runs before startWorkers: a subnet key
-		// may still need the subnet worker, so synchronously waiting here would
-		// block the worker that produces it. The rate-limited repair worker starts
-		// afterward and retries until the key is available. Detection logs a
-		// Warning requiring a Cilium restart for already-created endpoints.
-		c.enqueuePodTunnelKeyRepair(pod)
+		// tunnel_key and allocated annotations. Repair synchronously when status
+		// is ready; only an unavailable key or transient failure is queued because
+		// InitIPAM runs before the subnet/repair workers needed to finish it.
+		// Detection logs a Warning requiring a Cilium restart for existing endpoints.
+		c.repairPodTunnelKeyOnStartup(pod)
 
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {
 			klog.Errorf("failed to get pod kubeovn nets %s.%s address %s: %v", pod.Name, pod.Namespace, pod.Annotations[util.IPAddressAnnotation], err)
 			// The pod is skipped for IPAM restoration only; its tunnel_key
-			// repair was already enqueued above.
+			// startup repair was already attempted above.
 			continue
 		}
 

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -444,6 +444,10 @@ func (c *Controller) InitIPAM() error {
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {
 			klog.Errorf("failed to get pod kubeovn nets %s.%s address %s: %v", pod.Name, pod.Namespace, pod.Annotations[util.IPAddressAnnotation], err)
+			// The pod is skipped for IPAM and for the tunnel_key repair sweep;
+			// observable via metricPodTunnelKeySkipped, healed by the periodic
+			// resync or the pod reconcile path once the network resolves.
+			metricPodTunnelKeySkipped.Inc()
 			continue
 		}
 

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -441,12 +441,10 @@ func (c *Controller) InitIPAM() error {
 			continue
 		}
 
-		// Enqueue OVN pods missing the tunnel_key (VNI) annotation into the
-		// dedicated repair queue. Cilium (native-vpc mode) keys pod identities
-		// by this annotation; pods allocated before the subnet tunnel key was
-		// synced from OVN SB (or before this code existed) keep a missing
-		// annotation forever. The enqueue is annotation-driven
-		// (podProvidersMissingTunnelKey), so it runs before the network
+		// Enqueue pods whose tunnel_key (VNI) annotation needs reconciliation into the
+		// dedicated repair queue. It restores missing/invalid OVN VPC keys and
+		// removes stale keys from vlan/underlay or non-OVN providers. The enqueue is annotation-driven
+		// (podProvidersNeedingTunnelKeyRepair), so it runs before the network
 		// resolution below and cannot be skipped by a transient NAD/namespace
 		// resolution failure - no periodic resync is needed. The repair handler
 		// retries until the subnet key becomes available, so pods are enqueued

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -442,11 +442,12 @@ func (c *Controller) InitIPAM() error {
 		}
 
 		// Startup fallback only: normal allocation atomically writes IP/network,
-		// tunnel_key and allocated annotations. This sweep repairs legacy or
-		// stale persisted annotations and logs a warning requiring a Cilium
-		// restart for already-created endpoints. It runs before network
-		// resolution, needs no periodic task, and retries until the subnet key
-		// becomes available.
+		// tunnel_key and allocated annotations. The queue is necessarily
+		// asynchronous because InitIPAM runs before startWorkers: a subnet key
+		// may still need the subnet worker, so synchronously waiting here would
+		// block the worker that produces it. The rate-limited repair worker starts
+		// afterward and retries until the key is available. Detection logs a
+		// Warning requiring a Cilium restart for already-created endpoints.
 		c.enqueuePodTunnelKeyRepair(pod)
 
 		podNets, err := c.getPodKubeovnNets(pod)

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -441,14 +441,12 @@ func (c *Controller) InitIPAM() error {
 			continue
 		}
 
-		// Enqueue pods whose tunnel_key (VNI) annotation needs reconciliation into the
-		// dedicated repair queue. It restores missing/invalid OVN VPC keys and
-		// removes stale keys from vlan/underlay or non-OVN providers. The enqueue is annotation-driven
-		// (podProvidersNeedingTunnelKeyRepair), so it runs before the network
-		// resolution below and cannot be skipped by a transient NAD/namespace
-		// resolution failure - no periodic resync is needed. The repair handler
-		// retries until the subnet key becomes available, so pods are enqueued
-		// even if it is still 0.
+		// Startup fallback only: normal allocation atomically writes IP/network,
+		// tunnel_key and allocated annotations. This sweep repairs legacy or
+		// stale persisted annotations and logs a warning requiring a Cilium
+		// restart for already-created endpoints. It runs before network
+		// resolution, needs no periodic task, and retries until the subnet key
+		// becomes available.
 		c.enqueuePodTunnelKeyRepair(pod)
 
 		podNets, err := c.getPodKubeovnNets(pod)

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -441,13 +441,23 @@ func (c *Controller) InitIPAM() error {
 			continue
 		}
 
+		// Enqueue OVN pods missing the tunnel_key (VNI) annotation into the
+		// dedicated repair queue. Cilium (native-vpc mode) keys pod identities
+		// by this annotation; pods allocated before the subnet tunnel key was
+		// synced from OVN SB (or before this code existed) keep a missing
+		// annotation forever. The enqueue is annotation-driven
+		// (podProvidersMissingTunnelKey), so it runs before the network
+		// resolution below and cannot be skipped by a transient NAD/namespace
+		// resolution failure - no periodic resync is needed. The repair handler
+		// retries until the subnet key becomes available, so pods are enqueued
+		// even if it is still 0.
+		c.enqueuePodTunnelKeyRepair(pod)
+
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {
 			klog.Errorf("failed to get pod kubeovn nets %s.%s address %s: %v", pod.Name, pod.Namespace, pod.Annotations[util.IPAddressAnnotation], err)
-			// The pod is skipped for IPAM and for the tunnel_key repair sweep;
-			// observable via metricPodTunnelKeySkipped, healed by the periodic
-			// resync or the pod reconcile path once the network resolves.
-			metricPodTunnelKeySkipped.Inc()
+			// The pod is skipped for IPAM restoration only; its tunnel_key
+			// repair was already enqueued above.
 			continue
 		}
 
@@ -476,15 +486,6 @@ func (c *Controller) InitIPAM() error {
 				// Append ExternalIds is added in v1.7, used for upgrading from v1.6.3. It should be deleted now since v1.7 is not used anymore.
 			}
 		}
-
-		// Enqueue OVN pods missing the tunnel_key (VNI) annotation into the
-		// dedicated repair queue. Cilium (native-vpc mode) keys pod identities
-		// by this annotation; pods allocated before the subnet tunnel key was
-		// synced from OVN SB (or before this code existed) keep a missing
-		// annotation forever. Reuses the pod-level filtering (hostNetwork,
-		// alive) done above. The repair handler retries until the subnet key
-		// becomes available, so pods are enqueued even if it is still 0.
-		c.enqueuePodTunnelKeyRepair(pod, podNets)
 	}
 
 	klog.Infof("Init IPAM from vip CR")

--- a/pkg/controller/net_metrics.go
+++ b/pkg/controller/net_metrics.go
@@ -74,4 +74,5 @@ func registerMetrics() {
 	metrics.Registry.MustRegister(metricCentralSubnetInfo)
 	metrics.Registry.MustRegister(metricSubnetIPAMInfo)
 	metrics.Registry.MustRegister(metricSubnetIPAssignedInfo)
+	registerTunnelKeyMetrics()
 }

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -610,12 +610,14 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 // is exactly the population flow 2 repairs.
 //
 // Known gaps (documented, not closed by code):
-//   - No metric counts pods missing the annotation or repairs skipped by the
-//     startup sweep (see TODO(metrics) in resyncPodTunnelKeyOnce).
+//   - Repair progress is observable via pod_tunnel_key_missing (gap size at
+//     the last resync), pod_tunnel_key_repair_total and
+//     pod_tunnel_key_repair_skipped_total (see tunnel_key_metrics.go).
 //   - Repair keying is by podNet.ProviderName (AllocatedAnnotationTemplate /
-//     TunnelKeyAnnotationTemplate); a mismatch with the key Cilium actually
-//     reads for a multus secondary NIC would write an annotation that is not
-//     honored (TODO: confirm the provider-name contract with Cilium).
+//     TunnelKeyAnnotationTemplate). Cilium currently only recognizes the
+//     primary NIC (default provider, ovn.kubernetes.io/* annotations), so a
+//     mismatch on a multus secondary NIC would be harmless today; it only
+//     matters if Cilium starts keying secondary NICs.
 //   - The upgrade sequence above is operator discipline, not enforced by code:
 //     restarting cilium before the backfill completes leaves already-created
 //     endpoints on the non-VPC scheme until the next cilium restart.
@@ -644,7 +646,8 @@ func (c *Controller) tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 // reusing the already-resolved podNets. The enqueue is independent of the
 // subnet key state: the repair handler retries until the key becomes
 // available, so a pod whose subnet key is still 0 at init time is not lost.
-func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNet) {
+// It reports whether the pod was enqueued.
+func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNet) bool {
 	if !isPodAlive(pod) {
 		// Match InitIPAM's pod-level filtering: a non-alive StatefulSet pod
 		// still holds its allocated IP and annotations (restored from the IP
@@ -652,7 +655,7 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNe
 		// time it is re-scheduled and goes through CNI ADD.
 		isStsPod, _, _ := isStatefulSetPod(pod)
 		if !isStsPod {
-			return
+			return false
 		}
 	}
 	for _, podNet := range podNets {
@@ -668,8 +671,9 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNe
 		key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 		c.repairTunnelKeyQueue.Add(key)
 		klog.Infof("enqueued tunnel_key repair for pod %s", key)
-		return
+		return true
 	}
+	return false
 }
 
 // handleRepairTunnelKey patches the tunnel_key (VNI) annotation onto pods that
@@ -741,6 +745,7 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 		klog.Errorf("failed to patch tunnel key annotation for pod %s/%s: %v", namespace, name, err)
 		return err
 	}
+	metricPodTunnelKeyRepaired.Inc()
 	klog.Infof("repaired tunnel key annotation for pod %s/%s", namespace, name)
 	return nil
 }
@@ -755,18 +760,19 @@ const tunnelKeyResyncInterval = 5 * time.Minute
 
 // resyncPodTunnelKeyOnce is one tick of the periodic tunnel_key resync: it
 // lists all pods and enqueues the ones missing the annotation. The enqueue and
-// the repair handler are both idempotent, so repeated ticks are cheap.
+// the repair handler are both idempotent, so repeated ticks are cheap. It also
+// refreshes metricPodTunnelKeyMissing, the observable size of the gap.
 //
 // This is a defensive safety net: new pods cannot reach the missing-annotation
 // state (the allocation gate + atomic patch + CNI wait guarantee it, see the
 // Guarantee comment on tunnelKeyNotReady), so this only covers legacy pods the
-// startup sweep skipped. TODO(metrics): increment a counter here (and on the
-// getPodKubeovnNets error path) so silently skipped repairs are observable.
+// startup sweep skipped.
 func (c *Controller) resyncPodTunnelKeyOnce() error {
 	pods, err := c.podsLister.List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list pods for tunnel_key resync: %w", err)
 	}
+	missing := 0
 	for _, pod := range pods {
 		if pod.Spec.HostNetwork || !isPodAlive(pod) {
 			// Same filtering as InitIPAM and enqueuePodTunnelKeyRepair:
@@ -779,11 +785,15 @@ func (c *Controller) resyncPodTunnelKeyOnce() error {
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {
 			// Transient resolution failures are retried on the next tick.
+			metricPodTunnelKeySkipped.Inc()
 			klog.Errorf("failed to get pod nets for %s/%s during tunnel_key resync: %v", pod.Namespace, pod.Name, err)
 			continue
 		}
-		c.enqueuePodTunnelKeyRepair(pod, podNets)
+		if c.enqueuePodTunnelKeyRepair(pod, podNets) {
+			missing++
+		}
 	}
+	metricPodTunnelKeyMissing.Set(float64(missing))
 	return nil
 }
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -572,23 +572,32 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 // allocation gate + atomic patch for new pods, and the startup backfill via
 // repairTunnelKeyQueue for legacy pods) plus the upgrade sequence and known
 // gaps are documented in docs/tunnel-key-annotation-guarantee.md.
-//
+
+// OVN Datapath_Binding.tunnel_key is a 24-bit value with zero reserved.
+const maxTunnelKey = 1<<24 - 1
+
+func isValidTunnelKey(key int) bool {
+	return key > 0 && key <= maxTunnelKey
+}
+
 // tunnelKeyNotReady reports whether an IP must not be allocated from the given subnet yet
-// because its tunnel key (VNI) has not been synced from OVN SB (still 0).
+// because its tunnel key (VNI) has not been synced from OVN SB or is outside the valid range.
 //
 // The pod allocation path does NOT wait for subnet.Status.Ready: once the subnet is registered
 // in IPAM during subnet reconciliation, pod workers can start allocating IPs from it, possibly
-// before the tunnel key has been synced from OVN SB. Allocating in that window would record a
-// stale tunnel_key=0 in the pod annotation and make Cilium fall back to the non-VPC endpoint
+// before the tunnel key has been synced from OVN SB. Allocating in that window would record an
+// invalid tunnel_key in the pod annotation and make Cilium fall back to the non-VPC endpoint
 // scheme. reconcileAllocateSubnets checks this on the resolved subnet before it persists a pod.
-func (c *Controller) tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
-	return isOvnSubnet(subnet) && subnet.Status.TunnelKey == 0
+func tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
+	return isOvnSubnet(subnet) && !isValidTunnelKey(subnet.Status.TunnelKey)
 }
 
 // podProvidersMissingTunnelKey returns the providers of an allocated pod that
-// are missing their tunnel_key (VNI) annotation and carry a logical_switch
-// annotation. The OVN allocation path always writes logical_switch for OVN
-// subnets (provider "ovn", including vlan/underlay subnets) and removes it
+// lack a valid tunnel_key (VNI) annotation and carry a logical_switch
+// annotation. Missing, non-numeric or values outside OVN's 24-bit range
+// [1, 16777215] all need repair. The OVN allocation path always writes
+// logical_switch for OVN subnets (provider "ovn", including vlan/underlay
+// subnets) and removes it
 // for subnets whose provider is not ovn (kube-ovn acts as IPAM only, another
 // CNI configures the NIC), so an empty logical_switch reliably means the NIC
 // never gets a tunnel_key. The predicate is shared by enqueuePodTunnelKeyRepair
@@ -600,7 +609,8 @@ func (c *Controller) podProvidersMissingTunnelKey(pod *v1.Pod) []string {
 			continue
 		}
 		provider := strings.TrimSuffix(annotKey, util.AllocatedAnnotationSuffix)
-		if _, ok := pod.Annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)]; ok {
+		tunnelKey, err := strconv.Atoi(pod.Annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)])
+		if err == nil && isValidTunnelKey(tunnelKey) {
 			continue
 		}
 		if pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] == "" {
@@ -779,7 +789,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		}
 		patch[fmt.Sprintf(util.CidrAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.CIDRBlock
 		patch[fmt.Sprintf(util.GatewayAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.Gateway
-		if isOvnSubnet(podNet.Subnet) {
+		if isOvnSubnet(subnet) {
 			// Gate: never persist pod annotations for an OVN subnet whose tunnel key (VNI) has not
 			// been synced from OVN SB yet, otherwise Cilium falls back to the non-VPC endpoint scheme.
 			// This checks the resolved subnet (which may differ from podNet.Subnet for a static IP in a
@@ -787,7 +797,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			// earlier loop iterations may already have created idempotent LSP/IP CR state, but CNI-visible
 			// annotations remain all-or-nothing and the retry safely reconciles those objects again.
 			// A non-OVN resolved subnet has no tunnel key and is left as-is.
-			if c.tunnelKeyNotReady(subnet) {
+			if tunnelKeyNotReady(subnet) {
 				err := fmt.Errorf("subnet %s tunnel key not observed on allocation, requeuing", subnet.Name)
 				c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", err.Error())
 				klog.Error(err)
@@ -797,10 +807,8 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			if pod.Annotations[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] == "" {
 				patch[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] = c.config.PodNicType
 			}
-			// Record the tunnel key (VNI) so Cilium can recognize this as a VPC pod during CNI add.
-			if subnet.Status.TunnelKey != 0 {
-				patch[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)] = strconv.Itoa(subnet.Status.TunnelKey)
-			}
+			// The gate above guarantees a valid value for every resolved OVN subnet.
+			patch[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)] = strconv.Itoa(subnet.Status.TunnelKey)
 		} else {
 			patch[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podNet.ProviderName)] = nil
 			patch[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] = nil

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -646,7 +646,14 @@ func (c *Controller) tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 // available, so a pod whose subnet key is still 0 at init time is not lost.
 func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNet) {
 	if !isPodAlive(pod) {
-		return
+		// Match InitIPAM's pod-level filtering: a non-alive StatefulSet pod
+		// still holds its allocated IP and annotations (restored from the IP
+		// CR at startup) and is repaired too, so it has the annotation by the
+		// time it is re-scheduled and goes through CNI ADD.
+		isStsPod, _, _ := isStatefulSetPod(pod)
+		if !isStsPod {
+			return
+		}
 	}
 	for _, podNet := range podNets {
 		if !isOvnSubnet(podNet.Subnet) {
@@ -762,7 +769,12 @@ func (c *Controller) resyncPodTunnelKeyOnce() error {
 	}
 	for _, pod := range pods {
 		if pod.Spec.HostNetwork || !isPodAlive(pod) {
-			continue
+			// Same filtering as InitIPAM and enqueuePodTunnelKeyRepair:
+			// non-alive StatefulSet pods are repaired too.
+			isStsPod, _, _ := isStatefulSetPod(pod)
+			if !isStsPod {
+				continue
+			}
 		}
 		podNets, err := c.getPodKubeovnNets(pod)
 		if err != nil {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -573,13 +573,6 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 // repairTunnelKeyQueue for legacy pods) plus the upgrade sequence and known
 // gaps are documented in docs/tunnel-key-annotation-guarantee.md.
 
-// OVN Datapath_Binding.tunnel_key is a 24-bit value with zero reserved.
-const maxTunnelKey = 1<<24 - 1
-
-func isValidTunnelKey(key int) bool {
-	return key > 0 && key <= maxTunnelKey
-}
-
 // tunnelKeyNotReady reports whether an IP must not be allocated from the given subnet yet
 // because its tunnel key (VNI) has not been synced from OVN SB or is outside the valid range.
 //
@@ -589,7 +582,7 @@ func isValidTunnelKey(key int) bool {
 // invalid tunnel_key in the pod annotation and make Cilium fall back to the non-VPC endpoint
 // scheme. reconcileAllocateSubnets checks this on the resolved subnet before it persists a pod.
 func tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
-	return isOvnVpcSubnet(subnet) && !isValidTunnelKey(subnet.Status.TunnelKey)
+	return util.IsOvnVpcSubnet(subnet) && !util.IsValidTunnelKey(subnet.Status.TunnelKey)
 }
 
 // podProvidersNeedingTunnelKeyRepair returns allocated providers whose pod
@@ -622,15 +615,15 @@ func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
 			providers = append(providers, provider)
 			continue
 		}
-		if !isOvnVpcSubnet(subnet) {
+		if !util.IsOvnVpcSubnet(subnet) {
 			if hasTunnelKey {
 				providers = append(providers, provider)
 			}
 			continue
 		}
 		tunnelKey, err := strconv.Atoi(tunnelKeyValue)
-		if !hasTunnelKey || err != nil || !isValidTunnelKey(tunnelKey) ||
-			!isValidTunnelKey(subnet.Status.TunnelKey) || tunnelKey != subnet.Status.TunnelKey {
+		if !hasTunnelKey || err != nil || !util.IsValidTunnelKey(tunnelKey) ||
+			!util.IsValidTunnelKey(subnet.Status.TunnelKey) || tunnelKey != subnet.Status.TunnelKey {
 			providers = append(providers, provider)
 		}
 	}
@@ -734,11 +727,11 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 			klog.Errorf("failed to get subnet %s for pod %s/%s: %v", lsName, namespace, name, err)
 			return err
 		}
-		if !isOvnVpcSubnet(subnet) {
+		if !util.IsOvnVpcSubnet(subnet) {
 			patch[tunnelKeyAnnot] = nil
 			continue
 		}
-		if !isValidTunnelKey(subnet.Status.TunnelKey) {
+		if !util.IsValidTunnelKey(subnet.Status.TunnelKey) {
 			// Never record an invalid key; requeue until the key syncs.
 			keyNotReady = true
 			continue
@@ -807,7 +800,7 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 				patch[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] = c.config.PodNicType
 			}
 
-			if isOvnVpcSubnet(subnet) {
+			if util.IsOvnVpcSubnet(subnet) {
 				// Gate: never persist pod annotations for an OVN VPC subnet whose tunnel key (VNI)
 				// has not been synced from OVN SB yet, otherwise Cilium falls back to the non-VPC
 				// endpoint scheme. This checks the resolved subnet (which may differ from

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -591,9 +591,10 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 //     syncing it). A CNI ADD racing ahead of the repair is retried by the
 //     kubelet once the annotation is in place.
 //     Enqueue is not one-shot: the pod reconcile path (handleAddOrUpdatePod)
-//     and a periodic resync (resyncPodTunnelKey) also enqueue repairs, so a
-//     pod the startup sweep missed (e.g. its NAD or default subnet could not
-//     be resolved at that moment) heals on the next pod update or resync tick
+//     and a post-start resync (resyncPodTunnelKey, bounded to the backfill
+//     window) also enqueue repairs, so a pod the startup sweep missed (e.g.
+//     its NAD or default subnet could not be resolved at that moment) heals on
+//     the next pod update event, or on a resync tick within the window,
 //     instead of requiring another controller restart.
 //
 // Intended upgrade sequence: restart kube-ovn-controller first (this flow
@@ -611,8 +612,9 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 //
 // Known gaps (documented, not closed by code):
 //   - Repair progress is observable via pod_tunnel_key_missing (gap size at
-//     the last resync), pod_tunnel_key_repair_total and
-//     pod_tunnel_key_repair_skipped_total (see tunnel_key_metrics.go).
+//     the last resync during the post-start backfill window),
+//     pod_tunnel_key_repair_total and pod_tunnel_key_repair_skipped_total
+//     (see tunnel_key_metrics.go).
 //   - Repair keying is by podNet.ProviderName (AllocatedAnnotationTemplate /
 //     TunnelKeyAnnotationTemplate). Cilium currently only recognizes the
 //     primary NIC (default provider, ovn.kubernetes.io/* annotations), so a
@@ -751,12 +753,18 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 }
 
 // tunnelKeyResyncInterval is how often resyncPodTunnelKey re-scans all pods
-// for missing tunnel_key annotations. The startup sweep (InitIPAM) can miss a
-// pod when its network cannot be resolved at that moment (e.g. the NAD or the
-// default subnet is not yet available); the periodic resync heals those pods
-// without requiring a controller restart, and also covers pods that lose the
-// annotation at runtime.
-const tunnelKeyResyncInterval = 5 * time.Minute
+// for missing tunnel_key annotations during the post-start backfill window.
+const tunnelKeyResyncInterval = time.Minute
+
+// tunnelKeyResyncWindow bounds the periodic resync to the backfill phase right
+// after controller start. New pods cannot reach the missing-annotation state
+// (flow 1: allocation gate + atomic patch + CNI wait) and nothing removes the
+// annotation at runtime, so once the legacy-pod backfill settles there is
+// nothing left to scan for; the pod reconcile path (handleAddOrUpdatePod)
+// keeps repairing stragglers on their next update event. The cap also stops
+// the scan when a subnet tunnel key stays 0 and the repair queue keeps
+// retrying the same pods.
+const tunnelKeyResyncWindow = 10 * time.Minute
 
 // resyncPodTunnelKeyOnce is one tick of the periodic tunnel_key resync: it
 // lists all pods and enqueues the ones missing the annotation. The enqueue and
@@ -797,16 +805,24 @@ func (c *Controller) resyncPodTunnelKeyOnce() error {
 	return nil
 }
 
-// resyncPodTunnelKey periodically re-scans all pods and enqueues tunnel_key
-// repairs for any that are missing the annotation (see the Guarantee comment
-// on tunnelKeyNotReady). Started alongside the workers so the repair queue
-// keeps closing the gap even for pods the InitIPAM sweep missed.
+// resyncPodTunnelKey re-scans all pods and enqueues tunnel_key repairs for any
+// that are missing the annotation (see the Guarantee comment on
+// tunnelKeyNotReady), for a bounded window after controller start. Started
+// alongside the workers so the repair queue closes the gap even for pods the
+// InitIPAM sweep missed (e.g. their network was not resolvable at that
+// moment); it exits once the window expires so the full-pod scan does not run
+// forever.
 func (c *Controller) resyncPodTunnelKey(ctx context.Context) {
 	ticker := time.NewTicker(tunnelKeyResyncInterval)
 	defer ticker.Stop()
+	window := time.NewTimer(tunnelKeyResyncWindow)
+	defer window.Stop()
 	for {
 		select {
 		case <-ctx.Done():
+			return
+		case <-window.C:
+			klog.Info("tunnel_key resync window expired, stopping periodic scans")
 			return
 		case <-ticker.C:
 			if err := c.resyncPodTunnelKeyOnce(); err != nil {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -564,7 +564,7 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 
 // Guarantee: must-have tunnel_key.
 //
-// Every non-hostNetwork pod on an OVN subnet carries a non-zero
+// Every non-hostNetwork pod on a non-vlan OVN VPC subnet carries a valid
 // "ovn.kubernetes.io/tunnel_key" (VNI) annotation by the time its network is
 // configured (CNI ADD); Cilium (native-vpc mode) keys pod identities by it, so
 // a missing annotation would make the pod fall back to the non-VPC scheme and
@@ -589,47 +589,62 @@ func isValidTunnelKey(key int) bool {
 // invalid tunnel_key in the pod annotation and make Cilium fall back to the non-VPC endpoint
 // scheme. reconcileAllocateSubnets checks this on the resolved subnet before it persists a pod.
 func tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
-	return isOvnSubnet(subnet) && !isValidTunnelKey(subnet.Status.TunnelKey)
+	return isOvnVpcSubnet(subnet) && !isValidTunnelKey(subnet.Status.TunnelKey)
 }
 
-// podProvidersMissingTunnelKey returns the providers of an allocated pod that
-// lack a valid tunnel_key (VNI) annotation and carry a logical_switch
-// annotation. Missing, non-numeric or values outside OVN's 24-bit range
-// [1, 16777215] all need repair. The OVN allocation path always writes
-// logical_switch for OVN subnets (provider "ovn", including vlan/underlay
-// subnets) and removes it
-// for subnets whose provider is not ovn (kube-ovn acts as IPAM only, another
-// CNI configures the NIC), so an empty logical_switch reliably means the NIC
-// never gets a tunnel_key. The predicate is shared by enqueuePodTunnelKeyRepair
-// and handleRepairTunnelKey so the enqueue and the repair cannot drift apart.
-func (c *Controller) podProvidersMissingTunnelKey(pod *v1.Pod) []string {
+// podProvidersNeedingTunnelKeyRepair returns allocated providers whose pod
+// annotation does not match the subnet policy: non-vlan OVN VPC subnets need
+// the exact valid key from subnet status, while every other subnet type needs
+// no key.
+// The predicate is shared by enqueuePodTunnelKeyRepair and
+// handleRepairTunnelKey so enqueue and repair cannot drift apart.
+func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
 	var providers []string
 	for annotKey, v := range pod.Annotations {
 		if v != "true" || !strings.HasSuffix(annotKey, util.AllocatedAnnotationSuffix) {
 			continue
 		}
 		provider := strings.TrimSuffix(annotKey, util.AllocatedAnnotationSuffix)
-		tunnelKey, err := strconv.Atoi(pod.Annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)])
-		if err == nil && isValidTunnelKey(tunnelKey) {
+		tunnelKeyAnnotation := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)
+		tunnelKeyValue, hasTunnelKey := pod.Annotations[tunnelKeyAnnotation]
+		lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
+		if lsName == "" {
+			if hasTunnelKey {
+				providers = append(providers, provider)
+			}
 			continue
 		}
-		if pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] == "" {
-			// Non-OVN NIC: nothing to repair.
+
+		subnet, err := c.subnetsLister.Get(lsName)
+		if err != nil {
+			// Keep unresolved subnets in the result so the handler records the
+			// anomaly. It re-reads the lister while holding podKeyMutex.
+			providers = append(providers, provider)
 			continue
 		}
-		providers = append(providers, provider)
+		if !isOvnVpcSubnet(subnet) {
+			if hasTunnelKey {
+				providers = append(providers, provider)
+			}
+			continue
+		}
+		tunnelKey, err := strconv.Atoi(tunnelKeyValue)
+		if !hasTunnelKey || err != nil || !isValidTunnelKey(tunnelKey) ||
+			!isValidTunnelKey(subnet.Status.TunnelKey) || tunnelKey != subnet.Status.TunnelKey {
+			providers = append(providers, provider)
+		}
 	}
 	return providers
 }
 
-// enqueuePodTunnelKeyRepair enqueues an allocated OVN pod that is missing the
-// tunnel_key (VNI) annotation into the dedicated repair queue, so that
-// handleRepairTunnelKey patches it shortly after controller start.
+// enqueuePodTunnelKeyRepair enqueues an allocated pod whose tunnel_key (VNI)
+// annotations do not match subnet policy, so handleRepairTunnelKey can add a
+// VPC key or remove a stale key.
 //
 // It is called from InitIPAM's pod loop and from the pod reconcile path
-// (handleAddOrUpdatePod). It is annotation-driven (podProvidersMissingTunnelKey),
+// (handleAddOrUpdatePod). It is driven by podProvidersNeedingTunnelKeyRepair,
 // so it cannot be skipped by a transient NAD/namespace resolution failure - a
-// pod is enqueued whenever its own annotations say it is missing the key. The
+// pod is enqueued whenever its annotations need reconciliation. The
 // enqueue is independent of the subnet key state: the repair handler retries
 // until the key becomes available, so a pod whose subnet key is still 0 at
 // init time is not lost.
@@ -647,7 +662,7 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 			return
 		}
 	}
-	if len(c.podProvidersMissingTunnelKey(pod)) == 0 {
+	if len(c.podProvidersNeedingTunnelKeyRepair(pod)) == 0 {
 		return
 	}
 	key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
@@ -655,28 +670,20 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 	klog.V(3).Infof("enqueued tunnel_key repair for pod %s", key)
 }
 
-// handleRepairTunnelKey patches the tunnel_key (VNI) annotation onto pods that
-// are missing it. Cilium (native-vpc mode) keys pod identities by this
-// annotation, so a missing annotation makes the pod fall back to the non-VPC
-// scheme.
+// handleRepairTunnelKey reconciles per-provider tunnel_key (VNI) annotations:
+// non-vlan OVN VPC subnets get their valid key, while every other subnet type
+// has a stale key removed. Cilium (native-vpc mode) keys VPC pod identities by
+// this annotation, so a missing or stale annotation selects the wrong scheme.
 //
 // The handler is fed by the dedicated repairTunnelKeyQueue, which is populated
-// by enqueuePodTunnelKeyRepair during InitIPAM on controller start (the
-// allocation path never re-patches already-allocated pods). It is idempotent:
-// pods that already carry a valid annotation are left untouched, and a subnet
-// whose tunnel key is missing or outside OVN's valid range is never used to
-// record an invalid value - the handler returns an error instead so the
-// rate-limited queue retries until a valid key becomes available.
+// by enqueuePodTunnelKeyRepair during InitIPAM and pod updates. It is
+// idempotent: providers already matching their subnet policy are untouched;
+// invalid VPC subnet status is never written and instead triggers a retry.
 //
-// Repair is multi-NIC aware and driven purely by the per-provider annotations
-// the allocation wrote (allocated + logical_switch): every OVN subnet has its
-// own tunnel_key annotation. A provider is repaired only if it is marked
-// allocated and its logical_switch annotation resolves to an OVN subnet; the
-// subnet is never guessed from namespace/default fallbacks, because writing a
-// wrong VNI is worse than a missing one (nothing would correct it afterwards).
+// Reconciliation is multi-NIC aware and driven by allocated + logical_switch
+// annotations. The subnet is never guessed from namespace/default fallbacks.
 // Progress is not all-or-nothing: ready providers are patched in one call even
-// when another provider's subnet key is still 0 (the error then requeues for
-// the remainder).
+// when another VPC provider's key is not ready (the error requeues the rest).
 func (c *Controller) handleRepairTunnelKey(key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -708,9 +715,13 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 
 	patch := util.KVPatch{}
 	keyNotReady := false
-	for _, provider := range c.podProvidersMissingTunnelKey(pod) {
+	for _, provider := range c.podProvidersNeedingTunnelKeyRepair(pod) {
 		tunnelKeyAnnot := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)
 		lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
+		if lsName == "" {
+			patch[tunnelKeyAnnot] = nil
+			continue
+		}
 		subnet, err := c.subnetsLister.Get(lsName)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
@@ -723,7 +734,8 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 			klog.Errorf("failed to get subnet %s for pod %s/%s: %v", lsName, namespace, name, err)
 			return err
 		}
-		if !isOvnSubnet(subnet) {
+		if !isOvnVpcSubnet(subnet) {
+			patch[tunnelKeyAnnot] = nil
 			continue
 		}
 		if !isValidTunnelKey(subnet.Status.TunnelKey) {
@@ -745,7 +757,7 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 			return err
 		}
 		metricPodTunnelKeyRepairPatches.Inc()
-		klog.Infof("repaired tunnel key annotation for pod %s/%s", namespace, name)
+		klog.Infof("reconciled tunnel key annotation for pod %s/%s", namespace, name)
 	}
 	if keyNotReady {
 		return fmt.Errorf("tunnel key not observed for pod %s/%s, requeuing", namespace, name)
@@ -790,30 +802,33 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		patch[fmt.Sprintf(util.CidrAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.CIDRBlock
 		patch[fmt.Sprintf(util.GatewayAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.Gateway
 		if isOvnSubnet(subnet) {
-			// Gate: never persist pod annotations for an OVN subnet whose tunnel key (VNI) has not
-			// been synced from OVN SB yet, otherwise Cilium falls back to the non-VPC endpoint scheme.
-			// This checks the resolved subnet (which may differ from podNet.Subnet for a static IP in a
-			// multi-subnet namespace) before the annotation patch is committed. In a multi-NIC pod,
-			// earlier loop iterations may already have created idempotent LSP/IP CR state, but CNI-visible
-			// annotations remain all-or-nothing and the retry safely reconciles those objects again.
-			// A non-OVN resolved subnet has no tunnel key and is left as-is.
-			if tunnelKeyNotReady(subnet) {
-				err := fmt.Errorf("subnet %s tunnel key not observed on allocation, requeuing", subnet.Name)
-				c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", err.Error())
-				klog.Error(err)
-				return nil, err
-			}
 			patch[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podNet.ProviderName)] = subnet.Name
 			if pod.Annotations[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] == "" {
 				patch[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] = c.config.PodNicType
 			}
-			// The gate above guarantees a valid value for every resolved OVN subnet.
-			patch[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)] = strconv.Itoa(subnet.Status.TunnelKey)
+
+			if isOvnVpcSubnet(subnet) {
+				// Gate: never persist pod annotations for an OVN VPC subnet whose tunnel key (VNI)
+				// has not been synced from OVN SB yet, otherwise Cilium falls back to the non-VPC
+				// endpoint scheme. This checks the resolved subnet (which may differ from
+				// podNet.Subnet for a static IP in a multi-subnet namespace) before the annotation
+				// patch is committed. In a multi-NIC pod, earlier loop iterations may already have
+				// created idempotent LSP/IP CR state, but CNI-visible annotations remain all-or-
+				// nothing and the retry safely reconciles those objects again.
+				if tunnelKeyNotReady(subnet) {
+					err := fmt.Errorf("subnet %s tunnel key not observed on allocation, requeuing", subnet.Name)
+					c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", err.Error())
+					klog.Error(err)
+					return nil, err
+				}
+				patch[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)] = strconv.Itoa(subnet.Status.TunnelKey)
+			} else {
+				// OVN vlan/underlay subnets keep their OVN NIC annotations but never carry tunnel_key.
+				patch[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)] = nil
+			}
 		} else {
 			patch[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podNet.ProviderName)] = nil
 			patch[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] = nil
-			// Preserve the annotation invariant used by podProvidersMissingTunnelKey:
-			// a provider without logical_switch never carries a stale tunnel_key.
 			patch[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)] = nil
 		}
 		patch[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] = "true"

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -521,10 +521,10 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 
 	// Re-enqueue the tunnel_key repair for already-allocated OVN pods missing
 	// the annotation (idempotent, normally a no-op). Complements the InitIPAM
-	// startup sweep: a pod the sweep skipped because its network could not be
-	// resolved at that moment heals on its next update event instead of
-	// waiting for a controller restart.
-	c.enqueuePodTunnelKeyRepair(pod, podNets)
+	// startup sweep: a pod that appears or changes after startup heals on its
+	// next update event. Annotation-driven, so it does not depend on the
+	// network resolution above having succeeded.
+	c.enqueuePodTunnelKeyRepair(pod)
 
 	// check and do hotnoplug nic
 	if pod, err = c.syncKubeOvnNet(pod, podNets); err != nil {
@@ -583,17 +583,44 @@ func (c *Controller) tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 	return isOvnSubnet(subnet) && subnet.Status.TunnelKey == 0
 }
 
+// podProvidersMissingTunnelKey returns the providers of an allocated pod that
+// are missing their tunnel_key (VNI) annotation and carry a logical_switch
+// annotation. The OVN allocation path always writes logical_switch for OVN
+// subnets and removes it for non-OVN NICs (Vlan/underlay or IPAM-only multus
+// attachments), so an empty logical_switch reliably means no tunnel_key is
+// needed. The predicate is shared by enqueuePodTunnelKeyRepair and
+// handleRepairTunnelKey so the enqueue and the repair cannot drift apart.
+func (c *Controller) podProvidersMissingTunnelKey(pod *v1.Pod) []string {
+	var providers []string
+	for annotKey, v := range pod.Annotations {
+		if v != "true" || !strings.HasSuffix(annotKey, util.AllocatedAnnotationSuffix) {
+			continue
+		}
+		provider := strings.TrimSuffix(annotKey, util.AllocatedAnnotationSuffix)
+		if _, ok := pod.Annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)]; ok {
+			continue
+		}
+		if pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] == "" {
+			// Non-OVN NIC: nothing to repair.
+			continue
+		}
+		providers = append(providers, provider)
+	}
+	return providers
+}
+
 // enqueuePodTunnelKeyRepair enqueues an allocated OVN pod that is missing the
 // tunnel_key (VNI) annotation into the dedicated repair queue, so that
 // handleRepairTunnelKey patches it shortly after controller start.
 //
-// It is called from InitIPAM's pod loop, from the pod reconcile path
-// (handleAddOrUpdatePod) and from a periodic resync (resyncPodTunnelKeyOnce),
-// reusing the already-resolved podNets. The enqueue is independent of the
-// subnet key state: the repair handler retries until the key becomes
-// available, so a pod whose subnet key is still 0 at init time is not lost.
-// It reports whether the pod was enqueued.
-func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNet) bool {
+// It is called from InitIPAM's pod loop and from the pod reconcile path
+// (handleAddOrUpdatePod). It is annotation-driven (podProvidersMissingTunnelKey),
+// so it cannot be skipped by a transient NAD/namespace resolution failure - a
+// pod is enqueued whenever its own annotations say it is missing the key. The
+// enqueue is independent of the subnet key state: the repair handler retries
+// until the key becomes available, so a pod whose subnet key is still 0 at
+// init time is not lost. It reports whether the pod was enqueued.
+func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) bool {
 	if pod.Spec.HostNetwork {
 		return false
 	}
@@ -607,22 +634,13 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNe
 			return false
 		}
 	}
-	for _, podNet := range podNets {
-		if !isOvnSubnet(podNet.Subnet) {
-			continue
-		}
-		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] != "true" {
-			continue
-		}
-		if _, ok := pod.Annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)]; ok {
-			continue
-		}
-		key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-		c.repairTunnelKeyQueue.Add(key)
-		klog.V(3).Infof("enqueued tunnel_key repair for pod %s", key)
-		return true
+	if len(c.podProvidersMissingTunnelKey(pod)) == 0 {
+		return false
 	}
-	return false
+	key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+	c.repairTunnelKeyQueue.Add(key)
+	klog.V(3).Infof("enqueued tunnel_key repair for pod %s", key)
+	return true
 }
 
 // handleRepairTunnelKey patches the tunnel_key (VNI) annotation onto pods that
@@ -670,30 +688,22 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 	if pod.Spec.HostNetwork {
 		return nil
 	}
+	if !pod.DeletionTimestamp.IsZero() {
+		// The pod is being deleted: patching it is wasted work and would
+		// contend with the deletion/gc path.
+		return nil
+	}
 
 	patch := util.KVPatch{}
 	keyNotReady := false
-	for annotKey, v := range pod.Annotations {
-		if v != "true" || !strings.HasSuffix(annotKey, util.AllocatedAnnotationSuffix) {
-			continue
-		}
-		provider := strings.TrimSuffix(annotKey, util.AllocatedAnnotationSuffix)
+	for _, provider := range c.podProvidersMissingTunnelKey(pod) {
 		tunnelKeyAnnot := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)
-		if _, ok := pod.Annotations[tunnelKeyAnnot]; ok {
-			continue
-		}
 		lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
-		if lsName == "" {
-			// An OVN NIC always has its logical_switch annotation (allocation
-			// writes it for every OVN subnet), so allocated + empty
-			// logical_switch reliably means a non-OVN NIC (Vlan/underlay), which
-			// needs no tunnel_key: skip silently. Only a logical_switch that
-			// fails to resolve is the anomaly worth counting below.
-			continue
-		}
 		subnet, err := c.subnetsLister.Get(lsName)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
+				// The only real anomaly: the pod is allocated on a subnet that
+				// no longer exists, so it cannot be repaired.
 				metricPodTunnelKeySkipped.Inc()
 				klog.Warningf("pod %s/%s provider %s subnet %s not found, skip tunnel_key repair", namespace, name, provider, lsName)
 				continue
@@ -722,102 +732,13 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 			klog.Errorf("failed to patch tunnel key annotation for pod %s/%s: %v", namespace, name, err)
 			return err
 		}
-		metricPodTunnelKeyRepaired.Inc()
+		metricPodTunnelKeyRepairPatches.Inc()
 		klog.Infof("repaired tunnel key annotation for pod %s/%s", namespace, name)
 	}
 	if keyNotReady {
 		return fmt.Errorf("tunnel key not observed for pod %s/%s, requeuing", namespace, name)
 	}
 	return nil
-}
-
-// tunnelKeyResyncInterval is how often resyncPodTunnelKey re-scans all pods
-// for missing tunnel_key annotations during the post-start backfill window.
-const tunnelKeyResyncInterval = time.Minute
-
-// tunnelKeyResyncWindow bounds the periodic resync to the backfill phase right
-// after controller start. New pods cannot reach the missing-annotation state
-// (flow 1: allocation gate + atomic patch + CNI wait) and nothing removes the
-// annotation at runtime, so once the legacy-pod backfill settles there is
-// nothing left to scan for; the pod reconcile path (handleAddOrUpdatePod)
-// keeps repairing stragglers on their next update event. The cap also stops
-// the scan when a subnet tunnel key stays 0 and the repair queue keeps
-// retrying the same pods.
-const tunnelKeyResyncWindow = 10 * time.Minute
-
-// resyncPodTunnelKeyOnce is one tick of the periodic tunnel_key resync: it
-// lists all pods and enqueues the ones missing the annotation. The enqueue and
-// the repair handler are both idempotent, so repeated ticks are cheap. It also
-// refreshes metricPodTunnelKeyMissing, the observable size of the gap.
-//
-// This is a defensive safety net: new pods cannot reach the missing-annotation
-// state (the allocation gate + atomic patch + CNI wait guarantee it, see
-// docs/tunnel-key-annotation-guarantee.md), so this only covers legacy pods the
-// startup sweep skipped.
-func (c *Controller) resyncPodTunnelKeyOnce() error {
-	pods, err := c.podsLister.List(labels.Everything())
-	if err != nil {
-		return fmt.Errorf("failed to list pods for tunnel_key resync: %w", err)
-	}
-	missing := 0
-	for _, pod := range pods {
-		if pod.Spec.HostNetwork {
-			continue
-		}
-		if !isPodAlive(pod) {
-			// Same filtering as InitIPAM and enqueuePodTunnelKeyRepair:
-			// non-alive StatefulSet pods are repaired too.
-			isStsPod, _, _ := isStatefulSetPod(pod)
-			if !isStsPod {
-				continue
-			}
-		}
-		podNets, err := c.getPodKubeovnNets(pod)
-		if err != nil {
-			// Transient resolution failures are retried on the next tick.
-			metricPodTunnelKeySkipped.Inc()
-			klog.Errorf("failed to get pod nets for %s/%s during tunnel_key resync: %v", pod.Namespace, pod.Name, err)
-			continue
-		}
-		if c.enqueuePodTunnelKeyRepair(pod, podNets) {
-			missing++
-		}
-	}
-	metricPodTunnelKeyMissing.Set(float64(missing))
-	return nil
-}
-
-// resyncPodTunnelKey re-scans all pods and enqueues tunnel_key repairs for any
-// that are missing the annotation (see the Guarantee comment on
-// tunnelKeyNotReady), for a bounded window after controller start. Started
-// alongside the workers so the repair queue closes the gap even for pods the
-// InitIPAM sweep missed (e.g. their network was not resolvable at that
-// moment); it exits once the window expires so the full-pod scan does not run
-// forever.
-func (c *Controller) resyncPodTunnelKey(ctx context.Context) {
-	ticker := time.NewTicker(tunnelKeyResyncInterval)
-	defer ticker.Stop()
-	window := time.NewTimer(tunnelKeyResyncWindow)
-	defer window.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-window.C:
-			// One last scan so the gauge reflects the final state after the
-			// repair workers have drained the queue, and pods enqueued late in
-			// the window are re-confirmed before the periodic scans stop.
-			if err := c.resyncPodTunnelKeyOnce(); err != nil {
-				klog.Errorf("tunnel_key resync failed: %v", err)
-			}
-			klog.Info("tunnel_key resync window expired, stopping periodic scans")
-			return
-		case <-ticker.C:
-			if err := c.resyncPodTunnelKeyOnce(); err != nil {
-				klog.Errorf("tunnel_key resync failed: %v", err)
-			}
-		}
-	}
 }
 
 // do the same thing as add pod

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -553,6 +553,41 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 	return c.reconcileRouteSubnets(pod, needRouteSubnets(pod, podNets))
 }
 
+// Guarantee: must-have tunnel_key.
+//
+// Every non-hostNetwork pod on an OVN subnet carries a non-zero
+// "ovn.kubernetes.io/tunnel_key" (VNI) annotation by the time its network is
+// configured (CNI ADD). Cilium (native-vpc mode) keys pod identities by this
+// annotation, so a missing annotation would make the pod fall back to the
+// non-VPC scheme and collide with overlapping VPC subnets. The guarantee holds
+// in both flows below:
+//
+//  1. Normal pod creation flow.
+//     reconcileAllocateSubnets refuses to allocate (requeues, persisting
+//     nothing) while the resolved subnet's tunnel key has not been synced from
+//     OVN SB (Status.TunnelKey == 0), and writes the tunnel_key annotation in
+//     the same atomic patch as allocated=true. The kube-ovn CNI server blocks
+//     until allocated=true, and Cilium (chained after kube-ovn, the primary
+//     CNI) only runs once kube-ovn's CNI ADD has succeeded, so by the time
+//     Cilium reads the pod, the annotation is present and non-zero.
+//
+//  2. kube-ovn-controller restart flow.
+//     - Pods created after the restart follow flow 1 (the gate lives in the
+//     allocation path and is unrelated to restarts).
+//     - Pods that already carry the annotation keep it (persisted in etcd).
+//     - Legacy pods allocated before the subnet tunnel key was synced (or
+//     before this code existed) are missing the annotation. On startup
+//     InitIPAM enqueues them into repairTunnelKeyQueue
+//     (enqueuePodTunnelKeyRepair); the repair worker patches them from
+//     subnet.Status.TunnelKey shortly after startup, retrying with backoff
+//     until the key becomes available (subnet reconcile may still be
+//     syncing it). A CNI ADD racing ahead of the repair is retried by the
+//     kubelet once the annotation is in place.
+//
+// Intended upgrade sequence: restart kube-ovn-controller first (this flow
+// backfills the annotations), then restart cilium so it re-reads them for
+// already-created endpoints.
+//
 // tunnelKeyNotReady reports whether an IP must not be allocated from the given subnet yet
 // because its tunnel key (VNI) has not been synced from OVN SB (still 0).
 //
@@ -563,6 +598,106 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 // scheme. reconcileAllocateSubnets checks this on the resolved subnet before it persists a pod.
 func (c *Controller) tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 	return isOvnSubnet(subnet) && subnet.Status.TunnelKey == 0
+}
+
+// enqueuePodTunnelKeyRepair enqueues an allocated OVN pod that is missing the
+// tunnel_key (VNI) annotation into the dedicated repair queue, so that
+// handleRepairTunnelKey patches it shortly after controller start.
+//
+// It is called from InitIPAM's pod loop, reusing its pod-level filtering
+// (hostNetwork, alive) and the already-resolved podNets. The enqueue is
+// independent of the subnet key state: the repair handler retries until the
+// key becomes available, so a pod whose subnet key is still 0 at init time is
+// not lost.
+func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNet) {
+	for _, podNet := range podNets {
+		if !isOvnSubnet(podNet.Subnet) {
+			continue
+		}
+		if pod.Annotations[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] != "true" {
+			continue
+		}
+		if _, ok := pod.Annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)]; ok {
+			continue
+		}
+		key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		c.repairTunnelKeyQueue.Add(key)
+		klog.Infof("enqueued tunnel_key repair for pod %s", key)
+		return
+	}
+}
+
+// handleRepairTunnelKey patches the tunnel_key (VNI) annotation onto pods that
+// are missing it. Cilium (native-vpc mode) keys pod identities by this
+// annotation, so a missing annotation makes the pod fall back to the non-VPC
+// scheme.
+//
+// The handler is fed by the dedicated repairTunnelKeyQueue, which is populated
+// by enqueuePodTunnelKeyRepair during InitIPAM on controller start (the
+// allocation path never re-patches already-allocated pods). It is idempotent:
+// pods that already carry the annotation are left untouched, and a subnet whose
+// tunnel key has not been synced yet (Status.TunnelKey == 0) is never used to
+// record a stale zero value - the handler returns an error instead so the
+// rate-limited queue retries until the key becomes available.
+func (c *Controller) handleRepairTunnelKey(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	pod, err := c.podsLister.Pods(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Errorf("failed to get pod %s/%s: %v", namespace, name, err)
+		return err
+	}
+	if pod.Spec.HostNetwork {
+		return nil
+	}
+
+	podNets, err := c.getPodKubeovnNets(pod)
+	if err != nil {
+		klog.Errorf("failed to get pod nets for %s/%s: %v", namespace, name, err)
+		return err
+	}
+
+	var patch = util.KVPatch{}
+	keyNotReady := false
+	for _, podNet := range podNets {
+		subnet := podNet.Subnet
+		if !isOvnSubnet(subnet) {
+			continue
+		}
+		annotKey := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)
+		if _, ok := pod.Annotations[annotKey]; ok {
+			continue
+		}
+		if subnet.Status.TunnelKey == 0 {
+			// Never record a stale zero key; requeue until the key syncs.
+			keyNotReady = true
+			continue
+		}
+		patch[annotKey] = strconv.Itoa(subnet.Status.TunnelKey)
+	}
+	if keyNotReady {
+		return fmt.Errorf("tunnel key not observed for pod %s/%s, requeuing", namespace, name)
+	}
+	if len(patch) == 0 {
+		return nil
+	}
+
+	if err := util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(namespace), name, patch); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		klog.Errorf("failed to patch tunnel key annotation for pod %s/%s: %v", namespace, name, err)
+		return err
+	}
+	klog.Infof("repaired tunnel key annotation for pod %s/%s", namespace, name)
+	return nil
 }
 
 // do the same thing as add pod

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -507,6 +507,15 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 		klog.Error(err)
 		return err
 	}
+
+	// Re-enqueue the tunnel_key repair for already-allocated OVN pods missing
+	// the annotation (idempotent, normally a no-op). Complements the InitIPAM
+	// startup sweep: a pod that appears or changes after startup heals on its
+	// next update event. Annotation-driven, so it must run before the early
+	// returns below (network validation / resolution): a legacy pod whose NAD
+	// or default subnet has broken since startup must still be repaired.
+	c.enqueuePodTunnelKeyRepair(pod)
+
 	if err := util.ValidatePodNetwork(pod.Annotations); err != nil {
 		klog.Errorf("validate pod %s/%s failed: %v", namespace, name, err)
 		c.recorder.Eventf(pod, v1.EventTypeWarning, "ValidatePodNetworkFailed", err.Error())
@@ -518,13 +527,6 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 		klog.Errorf("failed to get pod nets %v", err)
 		return err
 	}
-
-	// Re-enqueue the tunnel_key repair for already-allocated OVN pods missing
-	// the annotation (idempotent, normally a no-op). Complements the InitIPAM
-	// startup sweep: a pod that appears or changes after startup heals on its
-	// next update event. Annotation-driven, so it does not depend on the
-	// network resolution above having succeeded.
-	c.enqueuePodTunnelKeyRepair(pod)
 
 	// check and do hotnoplug nic
 	if pod, err = c.syncKubeOvnNet(pod, podNets); err != nil {
@@ -586,10 +588,11 @@ func (c *Controller) tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 // podProvidersMissingTunnelKey returns the providers of an allocated pod that
 // are missing their tunnel_key (VNI) annotation and carry a logical_switch
 // annotation. The OVN allocation path always writes logical_switch for OVN
-// subnets and removes it for non-OVN NICs (Vlan/underlay or IPAM-only multus
-// attachments), so an empty logical_switch reliably means no tunnel_key is
-// needed. The predicate is shared by enqueuePodTunnelKeyRepair and
-// handleRepairTunnelKey so the enqueue and the repair cannot drift apart.
+// subnets (provider "ovn", including vlan/underlay subnets) and removes it
+// for subnets whose provider is not ovn (kube-ovn acts as IPAM only, another
+// CNI configures the NIC), so an empty logical_switch reliably means the NIC
+// never gets a tunnel_key. The predicate is shared by enqueuePodTunnelKeyRepair
+// and handleRepairTunnelKey so the enqueue and the repair cannot drift apart.
 func (c *Controller) podProvidersMissingTunnelKey(pod *v1.Pod) []string {
 	var providers []string
 	for annotKey, v := range pod.Annotations {
@@ -619,10 +622,10 @@ func (c *Controller) podProvidersMissingTunnelKey(pod *v1.Pod) []string {
 // pod is enqueued whenever its own annotations say it is missing the key. The
 // enqueue is independent of the subnet key state: the repair handler retries
 // until the key becomes available, so a pod whose subnet key is still 0 at
-// init time is not lost. It reports whether the pod was enqueued.
-func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) bool {
+// init time is not lost.
+func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 	if pod.Spec.HostNetwork {
-		return false
+		return
 	}
 	if !isPodAlive(pod) {
 		// Match InitIPAM's pod-level filtering: a non-alive StatefulSet pod
@@ -631,16 +634,15 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) bool {
 		// time it is re-scheduled and goes through CNI ADD.
 		isStsPod, _, _ := isStatefulSetPod(pod)
 		if !isStsPod {
-			return false
+			return
 		}
 	}
 	if len(c.podProvidersMissingTunnelKey(pod)) == 0 {
-		return false
+		return
 	}
 	key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 	c.repairTunnelKeyQueue.Add(key)
 	klog.V(3).Infof("enqueued tunnel_key repair for pod %s", key)
-	return true
 }
 
 // handleRepairTunnelKey patches the tunnel_key (VNI) annotation onto pods that

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -577,13 +577,47 @@ func tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 	return util.IsOvnVpcSubnet(subnet) && !util.IsValidTunnelKey(subnet.Status.TunnelKey)
 }
 
+// podDefaultTunnelKeyPolicySatisfied is the O(1) fast path for the common
+// single-network pod. Multus/custom-default pods fall back to the complete
+// per-provider scan below.
+func (c *Controller) podDefaultTunnelKeyPolicySatisfied(pod *v1.Pod) bool {
+	annotations := pod.Annotations
+	if strings.TrimSpace(annotations[nadv1.NetworkAttachmentAnnot]) != "" ||
+		strings.TrimSpace(annotations[nadv1.NetworkStatusAnnot]) != "" ||
+		annotations[util.DefaultNetworkAnnotation] != "" {
+		return false
+	}
+	if annotations[util.AllocatedAnnotation] != "true" {
+		return true
+	}
+
+	tunnelKeyValue, hasTunnelKey := annotations[util.TunnelKeyAnnotation]
+	lsName := annotations[util.LogicalSwitchAnnotation]
+	if lsName == "" {
+		return !hasTunnelKey
+	}
+	subnet, err := c.subnetsLister.Get(lsName)
+	if err != nil {
+		return false
+	}
+	if !util.IsOvnVpcSubnet(subnet) {
+		return !hasTunnelKey
+	}
+	tunnelKey, err := strconv.Atoi(tunnelKeyValue)
+	return hasTunnelKey && err == nil && util.IsValidTunnelKey(tunnelKey) &&
+		util.IsValidTunnelKey(subnet.Status.TunnelKey) && tunnelKey == subnet.Status.TunnelKey
+}
+
 // podProvidersNeedingTunnelKeyRepair returns allocated providers whose pod
 // annotation does not match the subnet policy: non-vlan OVN VPC subnets need
 // the exact valid key from subnet status, while every other subnet type needs
-// no key.
-// The predicate is shared by repairPodTunnelKeyOnStartup and
+// no key. The predicate is shared by repairPodTunnelKeyOnStartup and
 // handleRepairTunnelKey so detection and reconciliation cannot drift apart.
 func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
+	if c.podDefaultTunnelKeyPolicySatisfied(pod) {
+		return nil
+	}
+
 	var providers []string
 	for annotKey, v := range pod.Annotations {
 		if v != "true" || !strings.HasSuffix(annotKey, util.AllocatedAnnotationSuffix) {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -780,11 +780,13 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		patch[fmt.Sprintf(util.CidrAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.CIDRBlock
 		patch[fmt.Sprintf(util.GatewayAnnotationTemplate, podNet.ProviderName)] = subnet.Spec.Gateway
 		if isOvnSubnet(podNet.Subnet) {
-			// Gate: never persist an OVN pod whose subnet tunnel key (VNI) has not been synced from
-			// OVN SB yet, otherwise Cilium falls back to the non-VPC endpoint scheme. This runs on the
-			// resolved subnet (which may differ from podNet.Subnet for a static IP in a multi-subnet
-			// namespace) before any LSP or annotation is persisted, so the pod is simply requeued
-			// until the key is ready. A non-OVN resolved subnet has no tunnel key and is left as-is.
+			// Gate: never persist pod annotations for an OVN subnet whose tunnel key (VNI) has not
+			// been synced from OVN SB yet, otherwise Cilium falls back to the non-VPC endpoint scheme.
+			// This checks the resolved subnet (which may differ from podNet.Subnet for a static IP in a
+			// multi-subnet namespace) before the annotation patch is committed. In a multi-NIC pod,
+			// earlier loop iterations may already have created idempotent LSP/IP CR state, but CNI-visible
+			// annotations remain all-or-nothing and the retry safely reconciles those objects again.
+			// A non-OVN resolved subnet has no tunnel key and is left as-is.
 			if c.tunnelKeyNotReady(subnet) {
 				err := fmt.Errorf("subnet %s tunnel key not observed on allocation, requeuing", subnet.Name)
 				c.recorder.Eventf(pod, v1.EventTypeWarning, "AcquireAddressFailed", err.Error())
@@ -802,6 +804,9 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 		} else {
 			patch[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, podNet.ProviderName)] = nil
 			patch[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] = nil
+			// Preserve the annotation invariant used by podProvidersMissingTunnelKey:
+			// a provider without logical_switch never carries a stale tunnel_key.
+			patch[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)] = nil
 		}
 		patch[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] = "true"
 		if vmKey != "" {

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -588,8 +588,11 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 //     (enqueuePodTunnelKeyRepair); the repair worker patches them from
 //     subnet.Status.TunnelKey shortly after startup, retrying with backoff
 //     until the key becomes available (subnet reconcile may still be
-//     syncing it). A CNI ADD racing ahead of the repair is retried by the
-//     kubelet once the annotation is in place.
+//     syncing it). Note the CNI server only waits for allocated=true, so a
+//     CNI ADD for a legacy pod racing ahead of the repair proceeds without
+//     the annotation; if the ADD succeeds there is no kubelet retry, and the
+//     stale Cilium endpoint is corrected by the ordered cilium restart in the
+//     upgrade sequence below.
 //     Enqueue is not one-shot: the pod reconcile path (handleAddOrUpdatePod)
 //     and a post-start resync (resyncPodTunnelKey, bounded to the backfill
 //     window) also enqueue repairs, so a pod the startup sweep missed (e.g.
@@ -623,9 +626,10 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 //   - The upgrade sequence above is operator discipline, not enforced by code:
 //     restarting cilium before the backfill completes leaves already-created
 //     endpoints on the non-VPC scheme until the next cilium restart.
-//   - A CNI ADD racing the repair for a legacy pod relies on the kubelet
-//     retrying once the annotation lands; Cilium itself may keep the stale
-//     endpoint until restarted (see the upgrade sequence).
+//   - A CNI ADD racing the repair for a legacy pod is not closed by the CNI
+//     server (it only waits for allocated=true) nor by a kubelet retry when
+//     the ADD succeeds; the stale Cilium endpoint is corrected by the ordered
+//     cilium restart in the upgrade sequence above.
 //
 // tunnelKeyNotReady reports whether an IP must not be allocated from the given subnet yet
 // because its tunnel key (VNI) has not been synced from OVN SB (still 0).

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -581,8 +581,8 @@ func tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 // annotation does not match the subnet policy: non-vlan OVN VPC subnets need
 // the exact valid key from subnet status, while every other subnet type needs
 // no key.
-// The predicate is shared by enqueuePodTunnelKeyRepair and
-// handleRepairTunnelKey so enqueue and repair cannot drift apart.
+// The predicate is shared by repairPodTunnelKeyOnStartup and
+// handleRepairTunnelKey so detection and reconciliation cannot drift apart.
 func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
 	var providers []string
 	for annotKey, v := range pod.Annotations {
@@ -622,15 +622,10 @@ func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
 	return providers
 }
 
-// enqueuePodTunnelKeyRepair enqueues an allocated pod whose tunnel_key (VNI)
-// annotations do not match subnet policy, so handleRepairTunnelKey can add a
-// VPC key or remove a stale key.
-//
-// It is called only from InitIPAM's startup pod sweep. It is driven by
-// podProvidersNeedingTunnelKeyRepair, so it cannot be skipped by a transient
-// NAD/namespace resolution failure. The enqueue is independent of subnet key
-// state: the repair handler retries until the key becomes available.
-func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
+// repairPodTunnelKeyOnStartup synchronously repairs persisted annotations
+// during InitIPAM whenever possible. Only repairs that need a future subnet
+// sync or hit a transient error are deferred to repairTunnelKeyQueue.
+func (c *Controller) repairPodTunnelKeyOnStartup(pod *v1.Pod) {
 	if pod.Spec.HostNetwork {
 		return
 	}
@@ -653,8 +648,14 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 	// warning visible so operators know this cluster contained legacy/stale
 	// tunnel_key data and must restart Cilium after the backfill, allowing
 	// already-created endpoints to reload the corrected VNI.
-	klog.Warningf("detected pod %s with inconsistent tunnel_key annotations for providers %v; enqueuing startup repair, restart Cilium after the backfill completes", key, providers)
-	c.repairTunnelKeyQueue.Add(key)
+	klog.Warningf("detected pod %s with inconsistent tunnel_key annotations for providers %v; attempting synchronous startup repair, restart Cilium after the backfill completes", key, providers)
+	if err := c.handleRepairTunnelKey(key); err != nil {
+		// InitIPAM runs before subnet/repair workers. Deferral is necessary only
+		// when those workers must first produce the key or retry a transient
+		// error; blocking here would prevent them from starting.
+		klog.Warningf("synchronous startup tunnel_key repair for pod %s is not complete: %v; deferring to the rate-limited repair queue", key, err)
+		c.repairTunnelKeyQueue.Add(key)
+	}
 }
 
 // handleRepairTunnelKey reconciles per-provider tunnel_key (VNI) annotations:
@@ -662,9 +663,9 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 // has a stale key removed. Cilium (native-vpc mode) keys VPC pod identities by
 // this annotation, so a missing or stale annotation selects the wrong scheme.
 //
-// The handler is fed by repairTunnelKeyQueue, populated once by InitIPAM at
-// controller startup. It is idempotent: providers already matching their
-// subnet policy are untouched;
+// The handler is first called synchronously by InitIPAM. If it cannot finish,
+// repairTunnelKeyQueue retries it after workers start. It is idempotent:
+// providers already matching their subnet policy are untouched;
 // invalid VPC subnet status is never written and instead triggers a retry.
 //
 // Reconciliation is multi-NIC aware and driven by allocated + logical_switch

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -622,27 +622,10 @@ func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
 	return providers
 }
 
-// repairPodTunnelKeyOnStartup synchronously repairs persisted annotations
-// during InitIPAM whenever possible. Only repairs that need a future subnet
-// sync or hit a transient error are deferred to repairTunnelKeyQueue.
-func (c *Controller) repairPodTunnelKeyOnStartup(pod *v1.Pod) {
-	if pod.Spec.HostNetwork {
-		return
-	}
-	if !isPodAlive(pod) {
-		// Match InitIPAM's pod-level filtering: a non-alive StatefulSet pod
-		// still holds its allocated IP and annotations (restored from the IP
-		// CR at startup) and is repaired too, so it has the annotation by the
-		// time it is re-scheduled and goes through CNI ADD.
-		isStsPod, _, _ := isStatefulSetPod(pod)
-		if !isStsPod {
-			return
-		}
-	}
-	providers := c.podProvidersNeedingTunnelKeyRepair(pod)
-	if len(providers) == 0 {
-		return
-	}
+// repairPodTunnelKeyOnStartup synchronously repairs the providers selected by
+// InitIPAM. Only repairs that need a future subnet sync or hit a transient
+// error are deferred to repairTunnelKeyQueue.
+func (c *Controller) repairPodTunnelKeyOnStartup(pod *v1.Pod, providers []string) {
 	key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 	// This is a startup fallback, never the normal allocation path. Keep the
 	// warning visible so operators know this cluster contained legacy/stale

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -684,10 +684,11 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 		}
 		lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
 		if lsName == "" {
-			// Never guess the subnet (namespace default fallback): a wrong VNI
-			// is worse than a missing one, so leave it and count the skip.
-			metricPodTunnelKeySkipped.Inc()
-			klog.Warningf("pod %s/%s provider %s has no logical_switch annotation, skip tunnel_key repair", namespace, name, provider)
+			// An OVN NIC always has its logical_switch annotation (allocation
+			// writes it for every OVN subnet), so allocated + empty
+			// logical_switch reliably means a non-OVN NIC (Vlan/underlay), which
+			// needs no tunnel_key: skip silently. Only a logical_switch that
+			// fails to resolve is the anomaly worth counting below.
 			continue
 		}
 		subnet, err := c.subnetsLister.Get(lsName)

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -564,72 +564,12 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 //
 // Every non-hostNetwork pod on an OVN subnet carries a non-zero
 // "ovn.kubernetes.io/tunnel_key" (VNI) annotation by the time its network is
-// configured (CNI ADD). Cilium (native-vpc mode) keys pod identities by this
-// annotation, so a missing annotation would make the pod fall back to the
-// non-VPC scheme and collide with overlapping VPC subnets. The guarantee holds
-// in both flows below:
-//
-//  1. Normal pod creation flow.
-//     reconcileAllocateSubnets refuses to allocate (requeues, persisting
-//     nothing) while the resolved subnet's tunnel key has not been synced from
-//     OVN SB (Status.TunnelKey == 0), and writes the tunnel_key annotation in
-//     the same atomic patch as allocated=true. The kube-ovn CNI server blocks
-//     until allocated=true, and Cilium (chained after kube-ovn, the primary
-//     CNI) only runs once kube-ovn's CNI ADD has succeeded, so by the time
-//     Cilium reads the pod, the annotation is present and non-zero.
-//
-//  2. kube-ovn-controller restart flow.
-//     - Pods created after the restart follow flow 1 (the gate lives in the
-//     allocation path and is unrelated to restarts).
-//     - Pods that already carry the annotation keep it (persisted in etcd).
-//     - Legacy pods allocated before the subnet tunnel key was synced (or
-//     before this code existed) are missing the annotation. On startup
-//     InitIPAM enqueues them into repairTunnelKeyQueue
-//     (enqueuePodTunnelKeyRepair); the repair worker patches them from
-//     subnet.Status.TunnelKey shortly after startup, retrying with backoff
-//     until the key becomes available (subnet reconcile may still be
-//     syncing it). Note the CNI server only waits for allocated=true, so a
-//     CNI ADD for a legacy pod racing ahead of the repair proceeds without
-//     the annotation; if the ADD succeeds there is no kubelet retry, and the
-//     stale Cilium endpoint is corrected by the ordered cilium restart in the
-//     upgrade sequence below.
-//     Enqueue is not one-shot: the pod reconcile path (handleAddOrUpdatePod)
-//     and a post-start resync (resyncPodTunnelKey, bounded to the backfill
-//     window) also enqueue repairs, so a pod the startup sweep missed (e.g.
-//     its NAD or default subnet could not be resolved at that moment) heals on
-//     the next pod update event, or on a resync tick within the window,
-//     instead of requiring another controller restart.
-//
-// Intended upgrade sequence: restart kube-ovn-controller first (this flow
-// backfills the annotations), then restart cilium so it re-reads them for
-// already-created endpoints.
-//
-// Why flow 1 cannot produce a missing annotation: the pod NIC (LSP) is created
-// at a single point, reconcileAllocateSubnets, and that path returns an error
-// (persisting nothing) while tunnelKeyNotReady; tunnel_key and allocated=true
-// are written in the same atomic patch; and the CNI server blocks on
-// allocated=true before any NIC exists. So under the current code a pod either
-// carries the annotation or is still waiting at CNI ADD - a missing annotation
-// therefore implies a legacy pod created before this guarantee existed, which
-// is exactly the population flow 2 repairs.
-//
-// Known gaps (documented, not closed by code):
-//   - Repair progress is observable via pod_tunnel_key_missing (gap size at
-//     the last resync during the post-start backfill window),
-//     pod_tunnel_key_repair_total and pod_tunnel_key_repair_skipped_total
-//     (see tunnel_key_metrics.go).
-//   - Repair keying is by podNet.ProviderName (AllocatedAnnotationTemplate /
-//     TunnelKeyAnnotationTemplate). Cilium currently only recognizes the
-//     primary NIC (default provider, ovn.kubernetes.io/* annotations), so a
-//     mismatch on a multus secondary NIC would be harmless today; it only
-//     matters if Cilium starts keying secondary NICs.
-//   - The upgrade sequence above is operator discipline, not enforced by code:
-//     restarting cilium before the backfill completes leaves already-created
-//     endpoints on the non-VPC scheme until the next cilium restart.
-//   - A CNI ADD racing the repair for a legacy pod is not closed by the CNI
-//     server (it only waits for allocated=true) nor by a kubelet retry when
-//     the ADD succeeds; the stale Cilium endpoint is corrected by the ordered
-//     cilium restart in the upgrade sequence above.
+// configured (CNI ADD); Cilium (native-vpc mode) keys pod identities by it, so
+// a missing annotation would make the pod fall back to the non-VPC scheme and
+// collide with overlapping VPC subnets. The two flows upholding this (the
+// allocation gate + atomic patch for new pods, and the startup backfill via
+// repairTunnelKeyQueue for legacy pods) plus the upgrade sequence and known
+// gaps are documented in docs/tunnel-key-annotation-guarantee.md.
 //
 // tunnelKeyNotReady reports whether an IP must not be allocated from the given subnet yet
 // because its tunnel key (VNI) has not been synced from OVN SB (still 0).
@@ -654,6 +594,9 @@ func (c *Controller) tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 // available, so a pod whose subnet key is still 0 at init time is not lost.
 // It reports whether the pod was enqueued.
 func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNet) bool {
+	if pod.Spec.HostNetwork {
+		return false
+	}
 	if !isPodAlive(pod) {
 		// Match InitIPAM's pod-level filtering: a non-alive StatefulSet pod
 		// still holds its allocated IP and annotations (restored from the IP
@@ -676,7 +619,7 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNe
 		}
 		key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 		c.repairTunnelKeyQueue.Add(key)
-		klog.Infof("enqueued tunnel_key repair for pod %s", key)
+		klog.V(3).Infof("enqueued tunnel_key repair for pod %s", key)
 		return true
 	}
 	return false
@@ -694,12 +637,27 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNe
 // tunnel key has not been synced yet (Status.TunnelKey == 0) is never used to
 // record a stale zero value - the handler returns an error instead so the
 // rate-limited queue retries until the key becomes available.
+//
+// Repair is multi-NIC aware and driven purely by the per-provider annotations
+// the allocation wrote (allocated + logical_switch): every OVN subnet has its
+// own tunnel_key annotation. A provider is repaired only if it is marked
+// allocated and its logical_switch annotation resolves to an OVN subnet; the
+// subnet is never guessed from namespace/default fallbacks, because writing a
+// wrong VNI is worse than a missing one (nothing would correct it afterwards).
+// Progress is not all-or-nothing: ready providers are patched in one call even
+// when another provider's subnet key is still 0 (the error then requeues for
+// the remainder).
 func (c *Controller) handleRepairTunnelKey(key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
 		return nil
 	}
+
+	// Serialize with the pod reconcile path (handleAddOrUpdatePod) so a repair
+	// cannot race a release/re-allocation on the same pod.
+	c.podKeyMutex.LockKey(key)
+	defer func() { _ = c.podKeyMutex.UnlockKey(key) }()
 
 	pod, err := c.podsLister.Pods(namespace).Get(name)
 	if err != nil {
@@ -713,21 +671,36 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 		return nil
 	}
 
-	podNets, err := c.getPodKubeovnNets(pod)
-	if err != nil {
-		klog.Errorf("failed to get pod nets for %s/%s: %v", namespace, name, err)
-		return err
-	}
-
 	patch := util.KVPatch{}
 	keyNotReady := false
-	for _, podNet := range podNets {
-		subnet := podNet.Subnet
-		if !isOvnSubnet(subnet) {
+	for annotKey, v := range pod.Annotations {
+		if v != "true" || !strings.HasSuffix(annotKey, util.AllocatedAnnotationSuffix) {
 			continue
 		}
-		annotKey := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)
-		if _, ok := pod.Annotations[annotKey]; ok {
+		provider := strings.TrimSuffix(annotKey, util.AllocatedAnnotationSuffix)
+		tunnelKeyAnnot := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)
+		if _, ok := pod.Annotations[tunnelKeyAnnot]; ok {
+			continue
+		}
+		lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
+		if lsName == "" {
+			// Never guess the subnet (namespace default fallback): a wrong VNI
+			// is worse than a missing one, so leave it and count the skip.
+			metricPodTunnelKeySkipped.Inc()
+			klog.Warningf("pod %s/%s provider %s has no logical_switch annotation, skip tunnel_key repair", namespace, name, provider)
+			continue
+		}
+		subnet, err := c.subnetsLister.Get(lsName)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				metricPodTunnelKeySkipped.Inc()
+				klog.Warningf("pod %s/%s provider %s subnet %s not found, skip tunnel_key repair", namespace, name, provider, lsName)
+				continue
+			}
+			klog.Errorf("failed to get subnet %s for pod %s/%s: %v", lsName, namespace, name, err)
+			return err
+		}
+		if !isOvnSubnet(subnet) {
 			continue
 		}
 		if subnet.Status.TunnelKey == 0 {
@@ -735,24 +708,25 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 			keyNotReady = true
 			continue
 		}
-		patch[annotKey] = strconv.Itoa(subnet.Status.TunnelKey)
+		patch[tunnelKeyAnnot] = strconv.Itoa(subnet.Status.TunnelKey)
+	}
+
+	// Land whatever is ready before requeueing for the rest: a stuck subnet
+	// key on one NIC must not block the other NICs of the same pod.
+	if len(patch) != 0 {
+		if err := util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(namespace), name, patch); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			klog.Errorf("failed to patch tunnel key annotation for pod %s/%s: %v", namespace, name, err)
+			return err
+		}
+		metricPodTunnelKeyRepaired.Inc()
+		klog.Infof("repaired tunnel key annotation for pod %s/%s", namespace, name)
 	}
 	if keyNotReady {
 		return fmt.Errorf("tunnel key not observed for pod %s/%s, requeuing", namespace, name)
 	}
-	if len(patch) == 0 {
-		return nil
-	}
-
-	if err := util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(namespace), name, patch); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		klog.Errorf("failed to patch tunnel key annotation for pod %s/%s: %v", namespace, name, err)
-		return err
-	}
-	metricPodTunnelKeyRepaired.Inc()
-	klog.Infof("repaired tunnel key annotation for pod %s/%s", namespace, name)
 	return nil
 }
 
@@ -776,8 +750,8 @@ const tunnelKeyResyncWindow = 10 * time.Minute
 // refreshes metricPodTunnelKeyMissing, the observable size of the gap.
 //
 // This is a defensive safety net: new pods cannot reach the missing-annotation
-// state (the allocation gate + atomic patch + CNI wait guarantee it, see the
-// Guarantee comment on tunnelKeyNotReady), so this only covers legacy pods the
+// state (the allocation gate + atomic patch + CNI wait guarantee it, see
+// docs/tunnel-key-annotation-guarantee.md), so this only covers legacy pods the
 // startup sweep skipped.
 func (c *Controller) resyncPodTunnelKeyOnce() error {
 	pods, err := c.podsLister.List(labels.Everything())
@@ -786,7 +760,10 @@ func (c *Controller) resyncPodTunnelKeyOnce() error {
 	}
 	missing := 0
 	for _, pod := range pods {
-		if pod.Spec.HostNetwork || !isPodAlive(pod) {
+		if pod.Spec.HostNetwork {
+			continue
+		}
+		if !isPodAlive(pod) {
 			// Same filtering as InitIPAM and enqueuePodTunnelKeyRepair:
 			// non-alive StatefulSet pods are repaired too.
 			isStsPod, _, _ := isStatefulSetPod(pod)
@@ -826,6 +803,12 @@ func (c *Controller) resyncPodTunnelKey(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-window.C:
+			// One last scan so the gauge reflects the final state after the
+			// repair workers have drained the queue, and pods enqueued late in
+			// the window are re-confirmed before the periodic scans stop.
+			if err := c.resyncPodTunnelKeyOnce(); err != nil {
+				klog.Errorf("tunnel_key resync failed: %v", err)
+			}
 			klog.Info("tunnel_key resync window expired, stopping periodic scans")
 			return
 		case <-ticker.C:

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -519,6 +519,13 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 		return err
 	}
 
+	// Re-enqueue the tunnel_key repair for already-allocated OVN pods missing
+	// the annotation (idempotent, normally a no-op). Complements the InitIPAM
+	// startup sweep: a pod the sweep skipped because its network could not be
+	// resolved at that moment heals on its next update event instead of
+	// waiting for a controller restart.
+	c.enqueuePodTunnelKeyRepair(pod, podNets)
+
 	// check and do hotnoplug nic
 	if pod, err = c.syncKubeOvnNet(pod, podNets); err != nil {
 		klog.Errorf("failed to sync pod nets %v", err)
@@ -583,10 +590,38 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 //     until the key becomes available (subnet reconcile may still be
 //     syncing it). A CNI ADD racing ahead of the repair is retried by the
 //     kubelet once the annotation is in place.
+//     Enqueue is not one-shot: the pod reconcile path (handleAddOrUpdatePod)
+//     and a periodic resync (resyncPodTunnelKey) also enqueue repairs, so a
+//     pod the startup sweep missed (e.g. its NAD or default subnet could not
+//     be resolved at that moment) heals on the next pod update or resync tick
+//     instead of requiring another controller restart.
 //
 // Intended upgrade sequence: restart kube-ovn-controller first (this flow
 // backfills the annotations), then restart cilium so it re-reads them for
 // already-created endpoints.
+//
+// Why flow 1 cannot produce a missing annotation: the pod NIC (LSP) is created
+// at a single point, reconcileAllocateSubnets, and that path returns an error
+// (persisting nothing) while tunnelKeyNotReady; tunnel_key and allocated=true
+// are written in the same atomic patch; and the CNI server blocks on
+// allocated=true before any NIC exists. So under the current code a pod either
+// carries the annotation or is still waiting at CNI ADD - a missing annotation
+// therefore implies a legacy pod created before this guarantee existed, which
+// is exactly the population flow 2 repairs.
+//
+// Known gaps (documented, not closed by code):
+//   - No metric counts pods missing the annotation or repairs skipped by the
+//     startup sweep (see TODO(metrics) in resyncPodTunnelKeyOnce).
+//   - Repair keying is by podNet.ProviderName (AllocatedAnnotationTemplate /
+//     TunnelKeyAnnotationTemplate); a mismatch with the key Cilium actually
+//     reads for a multus secondary NIC would write an annotation that is not
+//     honored (TODO: confirm the provider-name contract with Cilium).
+//   - The upgrade sequence above is operator discipline, not enforced by code:
+//     restarting cilium before the backfill completes leaves already-created
+//     endpoints on the non-VPC scheme until the next cilium restart.
+//   - A CNI ADD racing the repair for a legacy pod relies on the kubelet
+//     retrying once the annotation lands; Cilium itself may keep the stale
+//     endpoint until restarted (see the upgrade sequence).
 //
 // tunnelKeyNotReady reports whether an IP must not be allocated from the given subnet yet
 // because its tunnel key (VNI) has not been synced from OVN SB (still 0).
@@ -604,12 +639,15 @@ func (c *Controller) tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 // tunnel_key (VNI) annotation into the dedicated repair queue, so that
 // handleRepairTunnelKey patches it shortly after controller start.
 //
-// It is called from InitIPAM's pod loop, reusing its pod-level filtering
-// (hostNetwork, alive) and the already-resolved podNets. The enqueue is
-// independent of the subnet key state: the repair handler retries until the
-// key becomes available, so a pod whose subnet key is still 0 at init time is
-// not lost.
+// It is called from InitIPAM's pod loop, from the pod reconcile path
+// (handleAddOrUpdatePod) and from a periodic resync (resyncPodTunnelKeyOnce),
+// reusing the already-resolved podNets. The enqueue is independent of the
+// subnet key state: the repair handler retries until the key becomes
+// available, so a pod whose subnet key is still 0 at init time is not lost.
 func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod, podNets []*kubeovnNet) {
+	if !isPodAlive(pod) {
+		return
+	}
 	for _, podNet := range podNets {
 		if !isOvnSubnet(podNet.Subnet) {
 			continue
@@ -664,7 +702,7 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 		return err
 	}
 
-	var patch = util.KVPatch{}
+	patch := util.KVPatch{}
 	keyNotReady := false
 	for _, podNet := range podNets {
 		subnet := podNet.Subnet
@@ -698,6 +736,62 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 	}
 	klog.Infof("repaired tunnel key annotation for pod %s/%s", namespace, name)
 	return nil
+}
+
+// tunnelKeyResyncInterval is how often resyncPodTunnelKey re-scans all pods
+// for missing tunnel_key annotations. The startup sweep (InitIPAM) can miss a
+// pod when its network cannot be resolved at that moment (e.g. the NAD or the
+// default subnet is not yet available); the periodic resync heals those pods
+// without requiring a controller restart, and also covers pods that lose the
+// annotation at runtime.
+const tunnelKeyResyncInterval = 5 * time.Minute
+
+// resyncPodTunnelKeyOnce is one tick of the periodic tunnel_key resync: it
+// lists all pods and enqueues the ones missing the annotation. The enqueue and
+// the repair handler are both idempotent, so repeated ticks are cheap.
+//
+// This is a defensive safety net: new pods cannot reach the missing-annotation
+// state (the allocation gate + atomic patch + CNI wait guarantee it, see the
+// Guarantee comment on tunnelKeyNotReady), so this only covers legacy pods the
+// startup sweep skipped. TODO(metrics): increment a counter here (and on the
+// getPodKubeovnNets error path) so silently skipped repairs are observable.
+func (c *Controller) resyncPodTunnelKeyOnce() error {
+	pods, err := c.podsLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list pods for tunnel_key resync: %w", err)
+	}
+	for _, pod := range pods {
+		if pod.Spec.HostNetwork || !isPodAlive(pod) {
+			continue
+		}
+		podNets, err := c.getPodKubeovnNets(pod)
+		if err != nil {
+			// Transient resolution failures are retried on the next tick.
+			klog.Errorf("failed to get pod nets for %s/%s during tunnel_key resync: %v", pod.Namespace, pod.Name, err)
+			continue
+		}
+		c.enqueuePodTunnelKeyRepair(pod, podNets)
+	}
+	return nil
+}
+
+// resyncPodTunnelKey periodically re-scans all pods and enqueues tunnel_key
+// repairs for any that are missing the annotation (see the Guarantee comment
+// on tunnelKeyNotReady). Started alongside the workers so the repair queue
+// keeps closing the gap even for pods the InitIPAM sweep missed.
+func (c *Controller) resyncPodTunnelKey(ctx context.Context) {
+	ticker := time.NewTicker(tunnelKeyResyncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := c.resyncPodTunnelKeyOnce(); err != nil {
+				klog.Errorf("tunnel_key resync failed: %v", err)
+			}
+		}
+	}
 }
 
 // do the same thing as add pod

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -577,10 +577,10 @@ func tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 	return util.IsOvnVpcSubnet(subnet) && !util.IsValidTunnelKey(subnet.Status.TunnelKey)
 }
 
-// podDefaultTunnelKeyPolicySatisfied is the O(1) fast path for the common
-// single-network pod. Multus/custom-default pods fall back to the complete
-// per-provider scan below.
-func (c *Controller) podDefaultTunnelKeyPolicySatisfied(pod *v1.Pod) bool {
+// canSkipDefaultTunnelKeyRepair is the O(1) fast path for the common
+// single-network pod. It returns true only when startup repair has no work;
+// Multus/custom-default pods fall back to the complete per-provider scan.
+func (c *Controller) canSkipDefaultTunnelKeyRepair(pod *v1.Pod) bool {
 	annotations := pod.Annotations
 	if strings.TrimSpace(annotations[nadv1.NetworkAttachmentAnnot]) != "" ||
 		strings.TrimSpace(annotations[nadv1.NetworkStatusAnnot]) != "" ||
@@ -588,9 +588,14 @@ func (c *Controller) podDefaultTunnelKeyPolicySatisfied(pod *v1.Pod) bool {
 		return false
 	}
 	if annotations[util.AllocatedAnnotation] != "true" {
+		// Unallocated pods belong to the normal allocation path, which writes
+		// IP/network, tunnel_key and allocated=true atomically. Startup repair
+		// must not preempt that path.
 		return true
 	}
 
+	// Presence alone is insufficient: a VPC key must also be valid and equal
+	// to the key of the pod's persisted logical_switch.
 	tunnelKeyValue, hasTunnelKey := annotations[util.TunnelKeyAnnotation]
 	lsName := annotations[util.LogicalSwitchAnnotation]
 	if lsName == "" {
@@ -614,7 +619,7 @@ func (c *Controller) podDefaultTunnelKeyPolicySatisfied(pod *v1.Pod) bool {
 // no key. The predicate is shared by repairPodTunnelKeyOnStartup and
 // handleRepairTunnelKey so detection and reconciliation cannot drift apart.
 func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
-	if c.podDefaultTunnelKeyPolicySatisfied(pod) {
+	if c.canSkipDefaultTunnelKeyRepair(pod) {
 		return nil
 	}
 

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -644,12 +644,17 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 			return
 		}
 	}
-	if len(c.podProvidersNeedingTunnelKeyRepair(pod)) == 0 {
+	providers := c.podProvidersNeedingTunnelKeyRepair(pod)
+	if len(providers) == 0 {
 		return
 	}
 	key := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+	// This is a startup fallback, never the normal allocation path. Keep the
+	// warning visible so operators know this cluster contained legacy/stale
+	// tunnel_key data and must restart Cilium after the backfill, allowing
+	// already-created endpoints to reload the corrected VNI.
+	klog.Warningf("detected pod %s with inconsistent tunnel_key annotations for providers %v; enqueuing startup repair, restart Cilium after the backfill completes", key, providers)
 	c.repairTunnelKeyQueue.Add(key)
-	klog.V(3).Infof("enqueued tunnel_key repair for pod %s", key)
 }
 
 // handleRepairTunnelKey reconciles per-provider tunnel_key (VNI) annotations:
@@ -739,7 +744,7 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 			return err
 		}
 		metricPodTunnelKeyRepairPatches.Inc()
-		klog.Infof("reconciled tunnel key annotation for pod %s/%s", namespace, name)
+		klog.Warningf("startup fallback reconciled tunnel_key annotations for pod %s/%s; restart Cilium after the backfill completes if an endpoint already exists", namespace, name)
 	}
 	if keyNotReady {
 		return fmt.Errorf("tunnel key not observed for pod %s/%s, requeuing", namespace, name)
@@ -813,6 +818,8 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			patch[fmt.Sprintf(util.PodNicAnnotationTemplate, podNet.ProviderName)] = nil
 			patch[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNet.ProviderName)] = nil
 		}
+		// Do not persist allocated independently: for an OVN VPC provider its
+		// IP/network annotations and tunnel_key are already in this same patch.
 		patch[fmt.Sprintf(util.AllocatedAnnotationTemplate, podNet.ProviderName)] = "true"
 		if vmKey != "" {
 			patch[fmt.Sprintf(util.VMAnnotationTemplate, podNet.ProviderName)] = vmName
@@ -910,6 +917,9 @@ func (c *Controller) reconcileAllocateSubnets(pod *v1.Pod, needAllocatePodNets [
 			return nil, err
 		}
 	}
+	// Commit all providers once. This single API patch is the normal-path
+	// invariant: IP/network data, VPC tunnel_key and allocated=true become
+	// visible together before kube-ovn CNI ADD can succeed.
 	if err = util.PatchAnnotations(c.config.KubeClient.CoreV1().Pods(namespace), name, patch); err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Sometimes pod is deleted between kube-ovn configure ovn-nb and patch pod.

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -577,52 +577,12 @@ func tunnelKeyNotReady(subnet *kubeovnv1.Subnet) bool {
 	return util.IsOvnVpcSubnet(subnet) && !util.IsValidTunnelKey(subnet.Status.TunnelKey)
 }
 
-// canSkipDefaultTunnelKeyRepair is the O(1) fast path for the common
-// single-network pod. It returns true only when startup repair has no work;
-// Multus/custom-default pods fall back to the complete per-provider scan.
-func (c *Controller) canSkipDefaultTunnelKeyRepair(pod *v1.Pod) bool {
-	annotations := pod.Annotations
-	if strings.TrimSpace(annotations[nadv1.NetworkAttachmentAnnot]) != "" ||
-		strings.TrimSpace(annotations[nadv1.NetworkStatusAnnot]) != "" ||
-		annotations[util.DefaultNetworkAnnotation] != "" {
-		return false
-	}
-	if annotations[util.AllocatedAnnotation] != "true" {
-		// Unallocated pods belong to the normal allocation path, which writes
-		// IP/network, tunnel_key and allocated=true atomically. Startup repair
-		// must not preempt that path.
-		return true
-	}
-
-	// Presence alone is insufficient: a VPC key must also be valid and equal
-	// to the key of the pod's persisted logical_switch.
-	tunnelKeyValue, hasTunnelKey := annotations[util.TunnelKeyAnnotation]
-	lsName := annotations[util.LogicalSwitchAnnotation]
-	if lsName == "" {
-		return !hasTunnelKey
-	}
-	subnet, err := c.subnetsLister.Get(lsName)
-	if err != nil {
-		return false
-	}
-	if !util.IsOvnVpcSubnet(subnet) {
-		return !hasTunnelKey
-	}
-	tunnelKey, err := strconv.Atoi(tunnelKeyValue)
-	return hasTunnelKey && err == nil && util.IsValidTunnelKey(tunnelKey) &&
-		util.IsValidTunnelKey(subnet.Status.TunnelKey) && tunnelKey == subnet.Status.TunnelKey
-}
-
 // podProvidersNeedingTunnelKeyRepair returns allocated providers whose pod
 // annotation does not match the subnet policy: non-vlan OVN VPC subnets need
 // the exact valid key from subnet status, while every other subnet type needs
 // no key. The predicate is shared by repairPodTunnelKeyOnStartup and
 // handleRepairTunnelKey so detection and reconciliation cannot drift apart.
 func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
-	if c.canSkipDefaultTunnelKeyRepair(pod) {
-		return nil
-	}
-
 	var providers []string
 	for annotKey, v := range pod.Annotations {
 		if v != "true" || !strings.HasSuffix(annotKey, util.AllocatedAnnotationSuffix) {
@@ -630,7 +590,7 @@ func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
 		}
 		provider := strings.TrimSuffix(annotKey, util.AllocatedAnnotationSuffix)
 		tunnelKeyAnnotation := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)
-		tunnelKeyValue, hasTunnelKey := pod.Annotations[tunnelKeyAnnotation]
+		_, hasTunnelKey := pod.Annotations[tunnelKeyAnnotation]
 		lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
 		if lsName == "" {
 			if hasTunnelKey {
@@ -652,9 +612,7 @@ func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
 			}
 			continue
 		}
-		tunnelKey, err := strconv.Atoi(tunnelKeyValue)
-		if !hasTunnelKey || err != nil || !util.IsValidTunnelKey(tunnelKey) ||
-			!util.IsValidTunnelKey(subnet.Status.TunnelKey) || tunnelKey != subnet.Status.TunnelKey {
+		if !util.IsTunnelKeyAnnotationValidForSubnet(pod.Annotations, provider, subnet) {
 			providers = append(providers, provider)
 		}
 	}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -663,10 +663,10 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 // The handler is fed by the dedicated repairTunnelKeyQueue, which is populated
 // by enqueuePodTunnelKeyRepair during InitIPAM on controller start (the
 // allocation path never re-patches already-allocated pods). It is idempotent:
-// pods that already carry the annotation are left untouched, and a subnet whose
-// tunnel key has not been synced yet (Status.TunnelKey == 0) is never used to
-// record a stale zero value - the handler returns an error instead so the
-// rate-limited queue retries until the key becomes available.
+// pods that already carry a valid annotation are left untouched, and a subnet
+// whose tunnel key is missing or outside OVN's valid range is never used to
+// record an invalid value - the handler returns an error instead so the
+// rate-limited queue retries until a valid key becomes available.
 //
 // Repair is multi-NIC aware and driven purely by the per-provider annotations
 // the allocation wrote (allocated + logical_switch): every OVN subnet has its
@@ -726,8 +726,8 @@ func (c *Controller) handleRepairTunnelKey(key string) error {
 		if !isOvnSubnet(subnet) {
 			continue
 		}
-		if subnet.Status.TunnelKey == 0 {
-			// Never record a stale zero key; requeue until the key syncs.
+		if !isValidTunnelKey(subnet.Status.TunnelKey) {
+			// Never record an invalid key; requeue until the key syncs.
 			keyNotReady = true
 			continue
 		}

--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -508,14 +508,6 @@ func (c *Controller) handleAddOrUpdatePod(key string) (err error) {
 		return err
 	}
 
-	// Re-enqueue the tunnel_key repair for already-allocated OVN pods missing
-	// the annotation (idempotent, normally a no-op). Complements the InitIPAM
-	// startup sweep: a pod that appears or changes after startup heals on its
-	// next update event. Annotation-driven, so it must run before the early
-	// returns below (network validation / resolution): a legacy pod whose NAD
-	// or default subnet has broken since startup must still be repaired.
-	c.enqueuePodTunnelKeyRepair(pod)
-
 	if err := util.ValidatePodNetwork(pod.Annotations); err != nil {
 		klog.Errorf("validate pod %s/%s failed: %v", namespace, name, err)
 		c.recorder.Eventf(pod, v1.EventTypeWarning, "ValidatePodNetworkFailed", err.Error())
@@ -634,13 +626,10 @@ func (c *Controller) podProvidersNeedingTunnelKeyRepair(pod *v1.Pod) []string {
 // annotations do not match subnet policy, so handleRepairTunnelKey can add a
 // VPC key or remove a stale key.
 //
-// It is called from InitIPAM's pod loop and from the pod reconcile path
-// (handleAddOrUpdatePod). It is driven by podProvidersNeedingTunnelKeyRepair,
-// so it cannot be skipped by a transient NAD/namespace resolution failure - a
-// pod is enqueued whenever its annotations need reconciliation. The
-// enqueue is independent of the subnet key state: the repair handler retries
-// until the key becomes available, so a pod whose subnet key is still 0 at
-// init time is not lost.
+// It is called only from InitIPAM's startup pod sweep. It is driven by
+// podProvidersNeedingTunnelKeyRepair, so it cannot be skipped by a transient
+// NAD/namespace resolution failure. The enqueue is independent of subnet key
+// state: the repair handler retries until the key becomes available.
 func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 	if pod.Spec.HostNetwork {
 		return
@@ -668,9 +657,9 @@ func (c *Controller) enqueuePodTunnelKeyRepair(pod *v1.Pod) {
 // has a stale key removed. Cilium (native-vpc mode) keys VPC pod identities by
 // this annotation, so a missing or stale annotation selects the wrong scheme.
 //
-// The handler is fed by the dedicated repairTunnelKeyQueue, which is populated
-// by enqueuePodTunnelKeyRepair during InitIPAM and pod updates. It is
-// idempotent: providers already matching their subnet policy are untouched;
+// The handler is fed by repairTunnelKeyQueue, populated once by InitIPAM at
+// controller startup. It is idempotent: providers already matching their
+// subnet policy are untouched;
 // invalid VPC subnet status is never written and instead triggers a retry.
 //
 // Reconciliation is multi-NIC aware and driven by allocated + logical_switch

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1056,9 +1056,9 @@ func TestTunnelKeyNotReady(t *testing.T) {
 	}{
 		{"ovn subnet, zero tunnel key is not ready", ovnSubnet(0), true},
 		{"ovn subnet, negative tunnel key is invalid", ovnSubnet(-1), true},
-		{"ovn subnet, out-of-range tunnel key is invalid", ovnSubnet(maxTunnelKey + 1), true},
+		{"ovn subnet, out-of-range tunnel key is invalid", ovnSubnet(util.MaxTunnelKey + 1), true},
 		{"ovn subnet, tunnel key ready", ovnSubnet(5), false},
-		{"ovn subnet, maximum tunnel key is valid", ovnSubnet(maxTunnelKey), false},
+		{"ovn subnet, maximum tunnel key is valid", ovnSubnet(util.MaxTunnelKey), false},
 		{"ovn vlan subnet keeps default tunnel key", vlanSubnet, false},
 		{"non-ovn subnet is ignored", nonOvnSubnet, false},
 		{"nil subnet is nil-safe", nil, false},
@@ -1151,7 +1151,7 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 		},
 		{
 			name:          "repairs out-of-range annotation",
-			pod:           ovnPod(ptr.To(strconv.Itoa(maxTunnelKey + 1))),
+			pod:           ovnPod(ptr.To(strconv.Itoa(util.MaxTunnelKey + 1))),
 			subnet:        ovnSubnet(1234),
 			wantAnnotated: true,
 			wantValue:     "1234",
@@ -1165,7 +1165,7 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 		{
 			name:    "requeues when subnet tunnel key is out of range",
 			pod:     ovnPod(nil),
-			subnet:  ovnSubnet(maxTunnelKey + 1),
+			subnet:  ovnSubnet(util.MaxTunnelKey + 1),
 			wantErr: true,
 		},
 		{

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1382,7 +1382,7 @@ func TestPodProvidersNeedingTunnelKeyRepair(t *testing.T) {
 }
 
 func TestRepairPodTunnelKeyOnStartup(t *testing.T) {
-	pod := func(name, subnet string, phase corev1.PodPhase, hostNetwork, sts bool) *corev1.Pod {
+	pod := func(name, subnet string, phase corev1.PodPhase, sts bool) *corev1.Pod {
 		p := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -1392,7 +1392,6 @@ func TestRepairPodTunnelKeyOnStartup(t *testing.T) {
 					util.LogicalSwitchAnnotation: subnet,
 				},
 			},
-			Spec:   corev1.PodSpec{HostNetwork: hostNetwork},
 			Status: corev1.PodStatus{Phase: phase},
 		}
 		if sts {
@@ -1408,11 +1407,9 @@ func TestRepairPodTunnelKeyOnStartup(t *testing.T) {
 		wantKey    string
 		wantQueued bool
 	}{
-		{name: "repairs synchronously when key is ready", pod: pod("ready", "ready-subnet", corev1.PodRunning, false, false), tunnelKey: 1234, wantKey: "1234"},
-		{name: "defers until subnet worker provides key", pod: pod("deferred", "deferred-subnet", corev1.PodRunning, false, false), wantQueued: true},
-		{name: "skips host network", pod: pod("host", "ready-subnet", corev1.PodRunning, true, false)},
-		{name: "skips terminated non-STS pod", pod: pod("dead", "ready-subnet", corev1.PodSucceeded, false, false)},
-		{name: "repairs non-alive STS synchronously", pod: pod("sts-0", "ready-subnet", corev1.PodSucceeded, false, true), tunnelKey: 1234, wantKey: "1234"},
+		{name: "repairs synchronously when key is ready", pod: pod("ready", "ready-subnet", corev1.PodRunning, false), tunnelKey: 1234, wantKey: "1234"},
+		{name: "defers until subnet worker provides key", pod: pod("deferred", "deferred-subnet", corev1.PodRunning, false), wantQueued: true},
+		{name: "repairs non-alive STS selected by InitIPAM", pod: pod("sts-0", "ready-subnet", corev1.PodSucceeded, true), tunnelKey: 1234, wantKey: "1234"},
 	}
 
 	for _, tt := range tests {
@@ -1426,7 +1423,9 @@ func TestRepairPodTunnelKeyOnStartup(t *testing.T) {
 			require.NoError(t, err)
 			c := fc.fakeController
 
-			c.repairPodTunnelKeyOnStartup(tt.pod)
+			providers := c.podProvidersNeedingTunnelKeyRepair(tt.pod)
+			require.NotEmpty(t, providers)
+			c.repairPodTunnelKeyOnStartup(tt.pod, providers)
 
 			updated, err := c.config.KubeClient.CoreV1().Pods("default").Get(context.Background(), tt.pod.Name, metav1.GetOptions{})
 			require.NoError(t, err)

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1060,10 +1060,13 @@ func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
 				// NIC 2: allocated on ovn-b whose key is not synced -> requeued, not patched
 				"net1.ovn.kubernetes.io/allocated":      "true",
 				"net1.ovn.kubernetes.io/logical_switch": "ovn-b",
-				// NIC 3: allocated but no logical_switch annotation -> skipped, never guessed
-				"net2.ovn.kubernetes.io/allocated": "true",
-				// NIC 4: has logical_switch but is NOT allocated -> skipped
-				"net3.ovn.kubernetes.io/logical_switch": "ovn-a",
+				// NIC 3: allocated non-OVN NIC with no logical_switch -> silent skip, not counted
+				"net2.kubernetes.io/allocated": "true",
+				// NIC 4: logical_switch points to a subnet that does not exist -> skipped and counted
+				"net3.ovn.kubernetes.io/allocated":      "true",
+				"net3.ovn.kubernetes.io/logical_switch": "ovn-c",
+				// NIC 5: has logical_switch but is NOT allocated -> skipped
+				"net4.ovn.kubernetes.io/logical_switch": "ovn-a",
 			},
 		},
 	}
@@ -1087,10 +1090,11 @@ func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
 	// NIC 2 must not be patched with a stale zero key.
 	_, ok := updated.Annotations["net1.ovn.kubernetes.io/tunnel_key"]
 	require.False(t, ok)
-	// NIC 4 (not allocated) must not be patched.
-	_, ok = updated.Annotations["net3.ovn.kubernetes.io/tunnel_key"]
+	// NIC 5 (not allocated) must not be patched.
+	_, ok = updated.Annotations["net4.ovn.kubernetes.io/tunnel_key"]
 	require.False(t, ok)
-	// NIC 3 (no logical_switch annotation) must be skipped and counted.
+	// Only the unresolvable logical_switch (NIC 4) counts as skipped; the
+	// non-OVN NIC 3 with no logical_switch must be silent.
 	require.Equal(t, float64(1), readCounter(t, metricPodTunnelKeySkipped)-skippedBefore)
 }
 

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1343,37 +1343,7 @@ func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
 	require.Equal(t, float64(1), readCounter(t, metricPodTunnelKeySkipped)-skippedBefore)
 }
 
-func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
-	podWith := func(name string, annos map[string]string, phase corev1.PodPhase, hostNetwork, sts bool) *corev1.Pod {
-		p := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        name,
-				Namespace:   "default",
-				Annotations: annos,
-			},
-			Spec:   corev1.PodSpec{HostNetwork: hostNetwork},
-			Status: corev1.PodStatus{Phase: phase},
-		}
-		if sts {
-			p.OwnerReferences = []metav1.OwnerReference{{
-				Kind:       util.KindStatefulSet,
-				Name:       "sts",
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-			}}
-		}
-		return p
-	}
-	ovnAnnotations := func(extra map[string]string) map[string]string {
-		annos := map[string]string{
-			util.AllocatedAnnotation:     "true",
-			util.LogicalSwitchAnnotation: "ovn-subnet",
-		}
-		for k, v := range extra {
-			annos[k] = v
-		}
-		return annos
-	}
-
+func TestPodProvidersNeedingTunnelKeyRepair(t *testing.T) {
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Subnets: []*kubeovnv1.Subnet{
 			{
@@ -1387,56 +1357,85 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 	require.NoError(t, err)
 	c := fc.fakeController
 
-	// allocated OVN pod missing tunnel_key: must be enqueued
-	c.enqueuePodTunnelKeyRepair(podWith("missing", ovnAnnotations(nil), corev1.PodRunning, false, false))
-	// matching valid tunnel_key: must not be enqueued
-	c.enqueuePodTunnelKeyRepair(podWith("has", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "1234"}), corev1.PodRunning, false, false))
-	// valid but stale key must be reconciled to subnet status
-	c.enqueuePodTunnelKeyRepair(podWith("stale-key", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "999"}), corev1.PodRunning, false, false))
-	// zero and non-numeric tunnel_key values do not satisfy the valid VNI guarantee
-	c.enqueuePodTunnelKeyRepair(podWith("zero-key", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "0"}), corev1.PodRunning, false, false))
-	c.enqueuePodTunnelKeyRepair(podWith("invalid-key", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "invalid"}), corev1.PodRunning, false, false))
-	// not allocated: must not be enqueued
-	c.enqueuePodTunnelKeyRepair(podWith("not-allocated", map[string]string{util.LogicalSwitchAnnotation: "ovn-subnet"}, corev1.PodRunning, false, false))
-	// non-OVN NIC (allocated but no logical_switch): no key matches policy
-	c.enqueuePodTunnelKeyRepair(podWith("non-ovn", map[string]string{util.AllocatedAnnotation: "true"}, corev1.PodRunning, false, false))
-	// stale key on a non-OVN provider must be removed even without logical_switch
-	c.enqueuePodTunnelKeyRepair(podWith("non-ovn-stale", map[string]string{
-		util.AllocatedAnnotation: "true",
-		util.TunnelKeyAnnotation: "1234",
-	}, corev1.PodRunning, false, false))
-	// OVN vlan/underlay subnet with no key already matches policy
-	c.enqueuePodTunnelKeyRepair(podWith("vlan", map[string]string{
-		util.AllocatedAnnotation:     "true",
-		util.LogicalSwitchAnnotation: "vlan-subnet",
-	}, corev1.PodRunning, false, false))
-	// stale key on an OVN vlan/underlay subnet must be removed
-	c.enqueuePodTunnelKeyRepair(podWith("vlan-stale", map[string]string{
-		util.AllocatedAnnotation:     "true",
-		util.LogicalSwitchAnnotation: "vlan-subnet",
-		util.TunnelKeyAnnotation:     "1234",
-	}, corev1.PodRunning, false, false))
-	// hostNetwork: must not be enqueued
-	c.enqueuePodTunnelKeyRepair(podWith("host-network", ovnAnnotations(nil), corev1.PodRunning, true, false))
-	// terminated non-STS pod: must not be enqueued
-	c.enqueuePodTunnelKeyRepair(podWith("dead", ovnAnnotations(nil), corev1.PodSucceeded, false, false))
-	// non-alive StatefulSet pod: must be enqueued (matches InitIPAM's filter)
-	c.enqueuePodTunnelKeyRepair(podWith("sts-0", ovnAnnotations(nil), corev1.PodSucceeded, false, true))
-
-	require.Equal(t, 7, c.repairTunnelKeyQueue.Len(), "only providers whose tunnel_key violates subnet policy must be enqueued")
-	keys := []string{}
-	for range c.repairTunnelKeyQueue.Len() {
-		key, _ := c.repairTunnelKeyQueue.Get()
-		c.repairTunnelKeyQueue.Done(key)
-		keys = append(keys, key)
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantRepair  bool
+	}{
+		{name: "missing VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet"}, wantRepair: true},
+		{name: "matching VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}},
+		{name: "stale VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "999"}, wantRepair: true},
+		{name: "invalid VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "invalid"}, wantRepair: true},
+		{name: "not allocated", annotations: map[string]string{util.LogicalSwitchAnnotation: "ovn-subnet"}},
+		{name: "non-OVN without key", annotations: map[string]string{util.AllocatedAnnotation: "true"}},
+		{name: "non-OVN stale key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.TunnelKeyAnnotation: "1234"}, wantRepair: true},
+		{name: "vlan without key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "vlan-subnet"}},
+		{name: "vlan stale key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "vlan-subnet", util.TunnelKeyAnnotation: "1234"}, wantRepair: true},
 	}
-	require.ElementsMatch(t, []string{
-		"default/missing",
-		"default/stale-key",
-		"default/zero-key",
-		"default/invalid-key",
-		"default/non-ovn-stale",
-		"default/vlan-stale",
-		"default/sts-0",
-	}, keys)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}}
+			require.Equal(t, tt.wantRepair, len(c.podProvidersNeedingTunnelKeyRepair(pod)) != 0)
+		})
+	}
+}
+
+func TestRepairPodTunnelKeyOnStartup(t *testing.T) {
+	pod := func(name, subnet string, phase corev1.PodPhase, hostNetwork, sts bool) *corev1.Pod {
+		p := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Annotations: map[string]string{
+					util.AllocatedAnnotation:     "true",
+					util.LogicalSwitchAnnotation: subnet,
+				},
+			},
+			Spec:   corev1.PodSpec{HostNetwork: hostNetwork},
+			Status: corev1.PodStatus{Phase: phase},
+		}
+		if sts {
+			p.OwnerReferences = []metav1.OwnerReference{{Kind: util.KindStatefulSet, Name: "sts", APIVersion: appsv1.SchemeGroupVersion.String()}}
+		}
+		return p
+	}
+
+	tests := []struct {
+		name       string
+		pod        *corev1.Pod
+		tunnelKey  int
+		wantKey    string
+		wantQueued bool
+	}{
+		{name: "repairs synchronously when key is ready", pod: pod("ready", "ready-subnet", corev1.PodRunning, false, false), tunnelKey: 1234, wantKey: "1234"},
+		{name: "defers until subnet worker provides key", pod: pod("deferred", "deferred-subnet", corev1.PodRunning, false, false), wantQueued: true},
+		{name: "skips host network", pod: pod("host", "ready-subnet", corev1.PodRunning, true, false)},
+		{name: "skips terminated non-STS pod", pod: pod("dead", "ready-subnet", corev1.PodSucceeded, false, false)},
+		{name: "repairs non-alive STS synchronously", pod: pod("sts-0", "ready-subnet", corev1.PodSucceeded, false, true), tunnelKey: 1234, wantKey: "1234"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnet := &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.pod.Annotations[util.LogicalSwitchAnnotation]},
+				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: tt.tunnelKey},
+			}
+			fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Subnets: []*kubeovnv1.Subnet{subnet}, Pods: []*corev1.Pod{tt.pod}})
+			require.NoError(t, err)
+			c := fc.fakeController
+
+			c.repairPodTunnelKeyOnStartup(tt.pod)
+
+			updated, err := c.config.KubeClient.CoreV1().Pods("default").Get(context.Background(), tt.pod.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantKey, updated.Annotations[util.TunnelKeyAnnotation])
+			if tt.wantQueued {
+				require.Equal(t, 1, c.repairTunnelKeyQueue.Len())
+			} else {
+				require.Zero(t, c.repairTunnelKeyQueue.Len())
+			}
+		})
+	}
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1344,44 +1344,6 @@ func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
 	require.Equal(t, float64(1), readCounter(t, metricPodTunnelKeySkipped)-skippedBefore)
 }
 
-func TestCanSkipDefaultTunnelKeyRepair(t *testing.T) {
-	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
-		Subnets: []*kubeovnv1.Subnet{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
-				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
-				Status:     kubeovnv1.SubnetStatus{TunnelKey: 1234},
-			},
-			{ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"}, Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"}},
-		},
-	})
-	require.NoError(t, err)
-	c := fc.fakeController
-
-	tests := []struct {
-		name        string
-		annotations map[string]string
-		want        bool
-	}{
-		{name: "unallocated pod", annotations: map[string]string{}, want: true},
-		{name: "matching VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}, want: true},
-		{name: "missing VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet"}},
-		{name: "stale VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "999"}},
-		{name: "vlan without key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "vlan-subnet"}, want: true},
-		{name: "vlan stale key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "vlan-subnet", util.TunnelKeyAnnotation: "1234"}},
-		{name: "multus pod uses full scan", annotations: map[string]string{nadv1.NetworkAttachmentAnnot: "default/net1", util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}},
-		{name: "network status uses full scan", annotations: map[string]string{nadv1.NetworkStatusAnnot: `[{"name":"default/net1"}]`, util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}},
-		{name: "custom default network uses full scan", annotations: map[string]string{util.DefaultNetworkAnnotation: "default/net1", util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}}
-			require.Equal(t, tt.want, c.canSkipDefaultTunnelKeyRepair(pod))
-		})
-	}
-}
-
 func TestPodProvidersNeedingTunnelKeyRepair(t *testing.T) {
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Subnets: []*kubeovnv1.Subnet{

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1299,6 +1299,7 @@ func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
 			Name:      "multi-nic",
 			Namespace: "default",
 			Annotations: map[string]string{
+				nadv1.NetworkAttachmentAnnot: "default/net1, default/net2, default/net3, default/net4",
 				// NIC 1: allocated on ovn-a, missing tunnel_key -> patched
 				util.AllocatedAnnotation:     "true",
 				util.LogicalSwitchAnnotation: "ovn-a",
@@ -1341,6 +1342,44 @@ func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
 	// Only the unresolvable logical_switch (NIC 4) counts as skipped; the
 	// non-OVN NIC 3 with no logical_switch must be silent.
 	require.Equal(t, float64(1), readCounter(t, metricPodTunnelKeySkipped)-skippedBefore)
+}
+
+func TestPodDefaultTunnelKeyPolicySatisfied(t *testing.T) {
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: 1234},
+			},
+			{ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"}, Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"}},
+		},
+	})
+	require.NoError(t, err)
+	c := fc.fakeController
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "unallocated pod", annotations: map[string]string{}, want: true},
+		{name: "matching VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}, want: true},
+		{name: "missing VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet"}},
+		{name: "stale VPC key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "999"}},
+		{name: "vlan without key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "vlan-subnet"}, want: true},
+		{name: "vlan stale key", annotations: map[string]string{util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "vlan-subnet", util.TunnelKeyAnnotation: "1234"}},
+		{name: "multus pod uses full scan", annotations: map[string]string{nadv1.NetworkAttachmentAnnot: "default/net1", util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}},
+		{name: "network status uses full scan", annotations: map[string]string{nadv1.NetworkStatusAnnot: `[{"name":"default/net1"}]`, util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}},
+		{name: "custom default network uses full scan", annotations: map[string]string{util.DefaultNetworkAnnotation: "default/net1", util.AllocatedAnnotation: "true", util.LogicalSwitchAnnotation: "ovn-subnet", util.TunnelKeyAnnotation: "1234"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}}
+			require.Equal(t, tt.want, c.podDefaultTunnelKeyPolicySatisfied(pod))
+		})
+	}
 }
 
 func TestPodProvidersNeedingTunnelKeyRepair(t *testing.T) {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -788,6 +788,59 @@ func TestReconcileAllocateSubnets_allowedWhenTunnelKeySynced(t *testing.T) {
 	require.Equal(t, "1234", allocated.Annotations[tunnelKeyKey])
 }
 
+func TestReconcileAllocateSubnetsClearsStaleTunnelKeyForNonOVNProvider(t *testing.T) {
+	const provider = "net1.default"
+	logicalSwitchKey := fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)
+	podNicKey := fmt.Sprintf(util.PodNicAnnotationTemplate, provider)
+	tunnelKeyKey := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)
+	allocatedKey := fmt.Sprintf(util.AllocatedAnnotationTemplate, provider)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				logicalSwitchKey: "old-ovn-subnet",
+				podNicKey:        util.VethType,
+				tunnelKeyKey:     "1234",
+			},
+		},
+	}
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ipam-only-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.0.2.0/24",
+			Protocol:  kubeovnv1.ProtocolIPv4,
+			Provider:  provider,
+		},
+		Status: kubeovnv1.SubnetStatus{V4AvailableIPs: 100},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Namespaces: []*corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "default"}}},
+		Subnets:    []*kubeovnv1.Subnet{subnet},
+		Pods:       []*corev1.Pod{pod},
+	})
+	require.NoError(t, err)
+	c := fc.fakeController
+	c.ipam = newIPAMForTest([]*kubeovnv1.Subnet{subnet})
+
+	allocated, err := c.reconcileAllocateSubnets(pod, []*kubeovnNet{{
+		Type:         providerTypeIPAM,
+		ProviderName: provider,
+		Subnet:       subnet,
+	}})
+	require.NoError(t, err)
+	require.NotNil(t, allocated)
+	require.Equal(t, "true", allocated.Annotations[allocatedKey])
+	_, ok := allocated.Annotations[logicalSwitchKey]
+	require.False(t, ok, "non-OVN provider must not keep a stale logical_switch")
+	_, ok = allocated.Annotations[podNicKey]
+	require.False(t, ok, "non-OVN provider must not keep a stale pod_nic")
+	_, ok = allocated.Annotations[tunnelKeyKey]
+	require.False(t, ok, "non-OVN provider must not keep a stale tunnel_key")
+}
+
 func TestGetNamedPortByNsReturnsCopy(t *testing.T) {
 	np := NewNamedPort()
 	pod := &corev1.Pod{

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -14,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ipam"
@@ -788,6 +790,68 @@ func TestReconcileAllocateSubnets_allowedWhenTunnelKeySynced(t *testing.T) {
 	require.Equal(t, "1234", allocated.Annotations[tunnelKeyKey])
 }
 
+func TestReconcileAllocateSubnetsUsesResolvedSubnetForTunnelKey(t *testing.T) {
+	initialSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ipam-only-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.0.3.0/24",
+			Protocol:  kubeovnv1.ProtocolIPv4,
+			Provider:  "net1.default",
+		},
+		Status: kubeovnv1.SubnetStatus{V4AvailableIPs: 100},
+	}
+	resolvedSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.0.4.0/24",
+			Protocol:  kubeovnv1.ProtocolIPv4,
+			Provider:  util.OvnProvider,
+		},
+		Status: kubeovnv1.SubnetStatus{V4AvailableIPs: 100, TunnelKey: 2345},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.IPAddressAnnotation: "10.0.4.5",
+			},
+		},
+	}
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+			Annotations: map[string]string{
+				util.LogicalSwitchAnnotation: initialSubnet.Name + "," + resolvedSubnet.Name,
+			},
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Namespaces: []*corev1.Namespace{namespace},
+		Subnets:    []*kubeovnv1.Subnet{initialSubnet, resolvedSubnet},
+		Pods:       []*corev1.Pod{pod},
+	})
+	require.NoError(t, err)
+	c := fc.fakeController
+	c.ipam = newIPAMForTest([]*kubeovnv1.Subnet{initialSubnet, resolvedSubnet})
+
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(
+		resolvedSubnet.Name, gomock.Any(), "10.0.4.5", gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil)
+
+	podNets, err := c.getPodKubeovnNets(pod)
+	require.NoError(t, err)
+	require.Len(t, podNets, 1)
+	require.Equal(t, initialSubnet.Name, podNets[0].Subnet.Name)
+
+	allocated, err := c.reconcileAllocateSubnets(pod, podNets)
+	require.NoError(t, err)
+	require.Equal(t, resolvedSubnet.Name, allocated.Annotations[util.LogicalSwitchAnnotation])
+	require.Equal(t, "2345", allocated.Annotations[util.TunnelKeyAnnotation])
+}
+
 func TestReconcileAllocateSubnetsClearsStaleTunnelKeyForNonOVNProvider(t *testing.T) {
 	const provider = "net1.default"
 	logicalSwitchKey := fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)
@@ -931,16 +995,18 @@ func TestTunnelKeyNotReady(t *testing.T) {
 		subnet   *kubeovnv1.Subnet
 		expected bool
 	}{
-		{"ovn subnet, tunnel key not ready", ovnSubnet(0), true},
+		{"ovn subnet, zero tunnel key is not ready", ovnSubnet(0), true},
+		{"ovn subnet, negative tunnel key is invalid", ovnSubnet(-1), true},
+		{"ovn subnet, out-of-range tunnel key is invalid", ovnSubnet(maxTunnelKey + 1), true},
 		{"ovn subnet, tunnel key ready", ovnSubnet(5), false},
+		{"ovn subnet, maximum tunnel key is valid", ovnSubnet(maxTunnelKey), false},
 		{"non-ovn subnet is ignored", underlaySubnet, false},
 		{"nil subnet is nil-safe", nil, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Controller{config: &Configuration{}}
-			assert.Equal(t, tt.expected, c.tunnelKeyNotReady(tt.subnet))
+			assert.Equal(t, tt.expected, tunnelKeyNotReady(tt.subnet))
 		})
 	}
 }
@@ -983,13 +1049,14 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 			wantValue:     "1234",
 		},
 		{
-			name: "leaves existing annotation untouched",
+			name: "leaves existing positive annotation untouched",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
 					Namespace: "default",
 					Annotations: map[string]string{
 						util.LogicalSwitchAnnotation: "ovn-subnet",
+						util.AllocatedAnnotation:     "true",
 						util.TunnelKeyAnnotation:     "999",
 					},
 				},
@@ -997,6 +1064,57 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 			subnet:        ovnSubnet(1234),
 			wantAnnotated: true,
 			wantValue:     "999",
+		},
+		{
+			name: "repairs zero annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "ovn-subnet",
+						util.AllocatedAnnotation:     "true",
+						util.TunnelKeyAnnotation:     "0",
+					},
+				},
+			},
+			subnet:        ovnSubnet(1234),
+			wantAnnotated: true,
+			wantValue:     "1234",
+		},
+		{
+			name: "repairs non-numeric annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "ovn-subnet",
+						util.AllocatedAnnotation:     "true",
+						util.TunnelKeyAnnotation:     "invalid",
+					},
+				},
+			},
+			subnet:        ovnSubnet(1234),
+			wantAnnotated: true,
+			wantValue:     "1234",
+		},
+		{
+			name: "repairs out-of-range annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "ovn-subnet",
+						util.AllocatedAnnotation:     "true",
+						util.TunnelKeyAnnotation:     strconv.Itoa(maxTunnelKey + 1),
+					},
+				},
+			},
+			subnet:        ovnSubnet(1234),
+			wantAnnotated: true,
+			wantValue:     "1234",
 		},
 		{
 			name: "requeues when subnet tunnel key not synced yet",
@@ -1030,6 +1148,21 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 				Spec:       kubeovnv1.SubnetSpec{Provider: "underlay.default"},
 				Status:     kubeovnv1.SubnetStatus{TunnelKey: 7},
 			},
+		},
+		{
+			name: "skips deleting pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pod",
+					Namespace:         "default",
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "ovn-subnet",
+						util.AllocatedAnnotation:     "true",
+					},
+				},
+			},
+			subnet: ovnSubnet(1234),
 		},
 		{
 			name: "skips hostNetwork pod",
@@ -1181,8 +1314,11 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 
 	// allocated OVN pod missing tunnel_key: must be enqueued
 	c.enqueuePodTunnelKeyRepair(podWith("missing", ovnAnnotations(nil), corev1.PodRunning, false, false))
-	// already annotated: must not be enqueued
+	// valid tunnel_key: must not be enqueued
 	c.enqueuePodTunnelKeyRepair(podWith("has", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "1234"}), corev1.PodRunning, false, false))
+	// zero and non-numeric tunnel_key values do not satisfy the valid VNI guarantee
+	c.enqueuePodTunnelKeyRepair(podWith("zero-key", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "0"}), corev1.PodRunning, false, false))
+	c.enqueuePodTunnelKeyRepair(podWith("invalid-key", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "invalid"}), corev1.PodRunning, false, false))
 	// not allocated: must not be enqueued
 	c.enqueuePodTunnelKeyRepair(podWith("not-allocated", map[string]string{util.LogicalSwitchAnnotation: "ovn-subnet"}, corev1.PodRunning, false, false))
 	// non-OVN NIC (allocated but no logical_switch): must not be enqueued
@@ -1194,12 +1330,42 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 	// non-alive StatefulSet pod: must be enqueued (matches InitIPAM's filter)
 	c.enqueuePodTunnelKeyRepair(podWith("sts-0", ovnAnnotations(nil), corev1.PodSucceeded, false, true))
 
-	require.Equal(t, 2, c.repairTunnelKeyQueue.Len(), "only allocated OVN pods missing tunnel_key must be enqueued")
+	require.Equal(t, 4, c.repairTunnelKeyQueue.Len(), "only allocated OVN pods without a valid tunnel_key must be enqueued")
 	keys := []string{}
 	for range c.repairTunnelKeyQueue.Len() {
 		key, _ := c.repairTunnelKeyQueue.Get()
 		c.repairTunnelKeyQueue.Done(key)
 		keys = append(keys, key)
 	}
-	require.ElementsMatch(t, []string{"default/missing", "default/sts-0"}, keys)
+	require.ElementsMatch(t, []string{
+		"default/missing",
+		"default/zero-key",
+		"default/invalid-key",
+		"default/sts-0",
+	}, keys)
+}
+
+func TestHandleAddOrUpdatePodEnqueuesTunnelKeyRepairBeforeValidation(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation:     "true",
+				util.LogicalSwitchAnnotation: "ovn-subnet",
+				util.IPAddressAnnotation:     "not-an-ip",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
+	require.NoError(t, err)
+	c := fc.fakeController
+
+	err = c.handleAddOrUpdatePod("default/legacy-pod")
+	require.Error(t, err, "invalid network annotation must still stop normal pod reconciliation")
+	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "repair must be enqueued before validation returns")
+	key, _ := c.repairTunnelKeyQueue.Get()
+	c.repairTunnelKeyQueue.Done(key)
+	require.Equal(t, "default/legacy-pod", key)
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -852,6 +852,60 @@ func TestReconcileAllocateSubnetsUsesResolvedSubnetForTunnelKey(t *testing.T) {
 	require.Equal(t, "2345", allocated.Annotations[util.TunnelKeyAnnotation])
 }
 
+func TestReconcileAllocateSubnetsOVNVlanKeepsNicAnnotationsWithoutTunnelKey(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.LogicalSwitchAnnotation: "vlan-subnet",
+				util.TunnelKeyAnnotation:     "1234",
+			},
+		},
+	}
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.0.5.0/24",
+			Protocol:  kubeovnv1.ProtocolIPv4,
+			Provider:  util.OvnProvider,
+			Vlan:      "vlan-a",
+		},
+		Status: kubeovnv1.SubnetStatus{V4AvailableIPs: 100},
+	}
+	vlan := &kubeovnv1.Vlan{
+		ObjectMeta: metav1.ObjectMeta{Name: "vlan-a"},
+		Spec:       kubeovnv1.VlanSpec{ID: 100, Provider: "provider-a"},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Namespaces: []*corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "default"}}},
+		Subnets:    []*kubeovnv1.Subnet{subnet},
+		Vlans:      []*kubeovnv1.Vlan{vlan},
+		Pods:       []*corev1.Pod{pod},
+	})
+	require.NoError(t, err)
+	c := fc.fakeController
+	c.config.PodNicType = util.VethType
+	c.ipam = newIPAMForTest([]*kubeovnv1.Subnet{subnet})
+
+	fc.mockOvnClient.EXPECT().CreateLogicalSwitchPort(
+		subnet.Name, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil)
+
+	allocated, err := c.reconcileAllocateSubnets(pod, []*kubeovnNet{{
+		Type:         providerTypeOriginal,
+		ProviderName: util.OvnProvider,
+		Subnet:       subnet,
+	}})
+	require.NoError(t, err)
+	require.Equal(t, subnet.Name, allocated.Annotations[util.LogicalSwitchAnnotation])
+	require.Equal(t, util.VethType, allocated.Annotations[fmt.Sprintf(util.PodNicAnnotationTemplate, util.OvnProvider)])
+	_, ok := allocated.Annotations[util.TunnelKeyAnnotation]
+	require.False(t, ok, "OVN vlan/underlay subnet must keep the default tunnel key")
+}
+
 func TestReconcileAllocateSubnetsClearsStaleTunnelKeyForNonOVNProvider(t *testing.T) {
 	const provider = "net1.default"
 	logicalSwitchKey := fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)
@@ -984,9 +1038,14 @@ func TestTunnelKeyNotReady(t *testing.T) {
 			Status:     kubeovnv1.SubnetStatus{TunnelKey: tunnelKey},
 		}
 	}
-	underlaySubnet := &kubeovnv1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{Name: "underlay-subnet"},
-		Spec:       kubeovnv1.SubnetSpec{Provider: "underlay.default"},
+	vlanSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"},
+		Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"},
+		Status:     kubeovnv1.SubnetStatus{TunnelKey: 0},
+	}
+	nonOvnSubnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ipam-only-subnet"},
+		Spec:       kubeovnv1.SubnetSpec{Provider: "net1.default"},
 		Status:     kubeovnv1.SubnetStatus{TunnelKey: 0},
 	}
 
@@ -1000,7 +1059,8 @@ func TestTunnelKeyNotReady(t *testing.T) {
 		{"ovn subnet, out-of-range tunnel key is invalid", ovnSubnet(maxTunnelKey + 1), true},
 		{"ovn subnet, tunnel key ready", ovnSubnet(5), false},
 		{"ovn subnet, maximum tunnel key is valid", ovnSubnet(maxTunnelKey), false},
-		{"non-ovn subnet is ignored", underlaySubnet, false},
+		{"ovn vlan subnet keeps default tunnel key", vlanSubnet, false},
+		{"non-ovn subnet is ignored", nonOvnSubnet, false},
 		{"nil subnet is nil-safe", nil, false},
 	}
 
@@ -1062,11 +1122,18 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 			wantValue:     "1234",
 		},
 		{
-			name:          "leaves existing positive annotation untouched",
+			name:          "leaves matching valid annotation untouched",
+			pod:           ovnPod(ptr.To("1234")),
+			subnet:        ovnSubnet(1234),
+			wantAnnotated: true,
+			wantValue:     "1234",
+		},
+		{
+			name:          "repairs stale but valid annotation",
 			pod:           ovnPod(ptr.To("999")),
 			subnet:        ovnSubnet(1234),
 			wantAnnotated: true,
-			wantValue:     "999",
+			wantValue:     "1234",
 		},
 		{
 			name:          "repairs zero annotation",
@@ -1102,7 +1169,43 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "skips non-ovn subnet",
+			name: "removes stale key from OVN vlan underlay subnet",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "vlan-subnet",
+						util.AllocatedAnnotation:     "true",
+						util.TunnelKeyAnnotation:     "1234",
+					},
+				},
+			},
+			subnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: 0},
+			},
+		},
+		{
+			name: "removes stale key without logical switch",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.AllocatedAnnotation: "true",
+						util.TunnelKeyAnnotation: "7",
+					},
+				},
+			},
+			subnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "unused-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: "net1.default"},
+			},
+		},
+		{
+			name: "removes stale key from non-ovn subnet",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
@@ -1110,6 +1213,7 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 					Annotations: map[string]string{
 						util.LogicalSwitchAnnotation: "underlay-subnet",
 						util.AllocatedAnnotation:     "true",
+						util.TunnelKeyAnnotation:     "7",
 					},
 				},
 			},
@@ -1255,21 +1359,48 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 		return annos
 	}
 
-	fc, err := newFakeControllerWithOptions(t, nil)
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Subnets: []*kubeovnv1.Subnet{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: 1234},
+			},
+			{ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"}, Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"}},
+		},
+	})
 	require.NoError(t, err)
 	c := fc.fakeController
 
 	// allocated OVN pod missing tunnel_key: must be enqueued
 	c.enqueuePodTunnelKeyRepair(podWith("missing", ovnAnnotations(nil), corev1.PodRunning, false, false))
-	// valid tunnel_key: must not be enqueued
+	// matching valid tunnel_key: must not be enqueued
 	c.enqueuePodTunnelKeyRepair(podWith("has", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "1234"}), corev1.PodRunning, false, false))
+	// valid but stale key must be reconciled to subnet status
+	c.enqueuePodTunnelKeyRepair(podWith("stale-key", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "999"}), corev1.PodRunning, false, false))
 	// zero and non-numeric tunnel_key values do not satisfy the valid VNI guarantee
 	c.enqueuePodTunnelKeyRepair(podWith("zero-key", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "0"}), corev1.PodRunning, false, false))
 	c.enqueuePodTunnelKeyRepair(podWith("invalid-key", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "invalid"}), corev1.PodRunning, false, false))
 	// not allocated: must not be enqueued
 	c.enqueuePodTunnelKeyRepair(podWith("not-allocated", map[string]string{util.LogicalSwitchAnnotation: "ovn-subnet"}, corev1.PodRunning, false, false))
-	// non-OVN NIC (allocated but no logical_switch): must not be enqueued
+	// non-OVN NIC (allocated but no logical_switch): no key matches policy
 	c.enqueuePodTunnelKeyRepair(podWith("non-ovn", map[string]string{util.AllocatedAnnotation: "true"}, corev1.PodRunning, false, false))
+	// stale key on a non-OVN provider must be removed even without logical_switch
+	c.enqueuePodTunnelKeyRepair(podWith("non-ovn-stale", map[string]string{
+		util.AllocatedAnnotation: "true",
+		util.TunnelKeyAnnotation: "1234",
+	}, corev1.PodRunning, false, false))
+	// OVN vlan/underlay subnet with no key already matches policy
+	c.enqueuePodTunnelKeyRepair(podWith("vlan", map[string]string{
+		util.AllocatedAnnotation:     "true",
+		util.LogicalSwitchAnnotation: "vlan-subnet",
+	}, corev1.PodRunning, false, false))
+	// stale key on an OVN vlan/underlay subnet must be removed
+	c.enqueuePodTunnelKeyRepair(podWith("vlan-stale", map[string]string{
+		util.AllocatedAnnotation:     "true",
+		util.LogicalSwitchAnnotation: "vlan-subnet",
+		util.TunnelKeyAnnotation:     "1234",
+	}, corev1.PodRunning, false, false))
 	// hostNetwork: must not be enqueued
 	c.enqueuePodTunnelKeyRepair(podWith("host-network", ovnAnnotations(nil), corev1.PodRunning, true, false))
 	// terminated non-STS pod: must not be enqueued
@@ -1277,7 +1408,7 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 	// non-alive StatefulSet pod: must be enqueued (matches InitIPAM's filter)
 	c.enqueuePodTunnelKeyRepair(podWith("sts-0", ovnAnnotations(nil), corev1.PodSucceeded, false, true))
 
-	require.Equal(t, 4, c.repairTunnelKeyQueue.Len(), "only allocated OVN pods without a valid tunnel_key must be enqueued")
+	require.Equal(t, 7, c.repairTunnelKeyQueue.Len(), "only providers whose tunnel_key violates subnet policy must be enqueued")
 	keys := []string{}
 	for range c.repairTunnelKeyQueue.Len() {
 		key, _ := c.repairTunnelKeyQueue.Get()
@@ -1286,8 +1417,11 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 	}
 	require.ElementsMatch(t, []string{
 		"default/missing",
+		"default/stale-key",
 		"default/zero-key",
 		"default/invalid-key",
+		"default/non-ovn-stale",
+		"default/vlan-stale",
 		"default/sts-0",
 	}, keys)
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1024,6 +1024,28 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 		}
 	}
 
+	ovnPod := func(tunnelKey *string) *corev1.Pod {
+		annotations := map[string]string{
+			util.LogicalSwitchAnnotation: "ovn-subnet",
+			util.AllocatedAnnotation:     "true",
+		}
+		if tunnelKey != nil {
+			annotations[util.TunnelKeyAnnotation] = *tunnelKey
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-pod",
+				Namespace:   "default",
+				Annotations: annotations,
+			},
+		}
+	}
+
+	deletingPod := ovnPod(nil)
+	deletingPod.DeletionTimestamp = ptr.To(metav1.Now())
+	hostNetworkPod := ovnPod(nil)
+	hostNetworkPod.Spec.HostNetwork = true
+
 	tests := []struct {
 		name          string
 		pod           *corev1.Pod
@@ -1033,102 +1055,50 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 		wantValue     string
 	}{
 		{
-			name: "patches missing tunnel_key from subnet status",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
-					Annotations: map[string]string{
-						util.LogicalSwitchAnnotation: "ovn-subnet",
-						util.AllocatedAnnotation:     "true",
-					},
-				},
-			},
+			name:          "patches missing tunnel_key from subnet status",
+			pod:           ovnPod(nil),
 			subnet:        ovnSubnet(1234),
 			wantAnnotated: true,
 			wantValue:     "1234",
 		},
 		{
-			name: "leaves existing positive annotation untouched",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
-					Annotations: map[string]string{
-						util.LogicalSwitchAnnotation: "ovn-subnet",
-						util.AllocatedAnnotation:     "true",
-						util.TunnelKeyAnnotation:     "999",
-					},
-				},
-			},
+			name:          "leaves existing positive annotation untouched",
+			pod:           ovnPod(ptr.To("999")),
 			subnet:        ovnSubnet(1234),
 			wantAnnotated: true,
 			wantValue:     "999",
 		},
 		{
-			name: "repairs zero annotation",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
-					Annotations: map[string]string{
-						util.LogicalSwitchAnnotation: "ovn-subnet",
-						util.AllocatedAnnotation:     "true",
-						util.TunnelKeyAnnotation:     "0",
-					},
-				},
-			},
+			name:          "repairs zero annotation",
+			pod:           ovnPod(ptr.To("0")),
 			subnet:        ovnSubnet(1234),
 			wantAnnotated: true,
 			wantValue:     "1234",
 		},
 		{
-			name: "repairs non-numeric annotation",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
-					Annotations: map[string]string{
-						util.LogicalSwitchAnnotation: "ovn-subnet",
-						util.AllocatedAnnotation:     "true",
-						util.TunnelKeyAnnotation:     "invalid",
-					},
-				},
-			},
+			name:          "repairs non-numeric annotation",
+			pod:           ovnPod(ptr.To("invalid")),
 			subnet:        ovnSubnet(1234),
 			wantAnnotated: true,
 			wantValue:     "1234",
 		},
 		{
-			name: "repairs out-of-range annotation",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
-					Annotations: map[string]string{
-						util.LogicalSwitchAnnotation: "ovn-subnet",
-						util.AllocatedAnnotation:     "true",
-						util.TunnelKeyAnnotation:     strconv.Itoa(maxTunnelKey + 1),
-					},
-				},
-			},
+			name:          "repairs out-of-range annotation",
+			pod:           ovnPod(ptr.To(strconv.Itoa(maxTunnelKey + 1))),
 			subnet:        ovnSubnet(1234),
 			wantAnnotated: true,
 			wantValue:     "1234",
 		},
 		{
-			name: "requeues when subnet tunnel key not synced yet",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
-					Annotations: map[string]string{
-						util.LogicalSwitchAnnotation: "ovn-subnet",
-						util.AllocatedAnnotation:     "true",
-					},
-				},
-			},
+			name:    "requeues when subnet tunnel key not synced yet",
+			pod:     ovnPod(nil),
 			subnet:  ovnSubnet(0),
+			wantErr: true,
+		},
+		{
+			name:    "requeues when subnet tunnel key is out of range",
+			pod:     ovnPod(nil),
+			subnet:  ovnSubnet(maxTunnelKey + 1),
 			wantErr: true,
 		},
 		{
@@ -1149,35 +1119,8 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 				Status:     kubeovnv1.SubnetStatus{TunnelKey: 7},
 			},
 		},
-		{
-			name: "skips deleting pod",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-pod",
-					Namespace:         "default",
-					DeletionTimestamp: ptr.To(metav1.Now()),
-					Annotations: map[string]string{
-						util.LogicalSwitchAnnotation: "ovn-subnet",
-						util.AllocatedAnnotation:     "true",
-					},
-				},
-			},
-			subnet: ovnSubnet(1234),
-		},
-		{
-			name: "skips hostNetwork pod",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
-					Annotations: map[string]string{
-						util.LogicalSwitchAnnotation: "ovn-subnet",
-					},
-				},
-				Spec: corev1.PodSpec{HostNetwork: true},
-			},
-			subnet: ovnSubnet(1234),
-		},
+		{name: "skips deleting pod", pod: deletingPod, subnet: ovnSubnet(1234)},
+		{name: "skips hostNetwork pod", pod: hostNetworkPod, subnet: ovnSubnet(1234)},
 	}
 
 	for _, tt := range tests {
@@ -1193,6 +1136,10 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 			err = c.handleRepairTunnelKey("default/test-pod")
 			if tt.wantErr {
 				require.Error(t, err)
+				updated, getErr := c.config.KubeClient.CoreV1().Pods("default").Get(context.Background(), "test-pod", metav1.GetOptions{})
+				require.NoError(t, getErr)
+				_, ok := updated.Annotations[util.TunnelKeyAnnotation]
+				require.False(t, ok, "invalid subnet tunnel key must never be patched")
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1077,6 +1077,45 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 	// subnet worker, so the init-before-subnet-sync ordering does not lose it.
 	c.enqueuePodTunnelKeyRepair(missing, ovnNet(0))
 	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "enqueue must be independent of the subnet key state")
+
+	// A non-alive StatefulSet pod must still be enqueued (it holds its
+	// allocated IP and will be re-scheduled), matching InitIPAM's filter;
+	// a non-alive regular pod must not.
+	stsPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sts-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation: "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind:       util.KindStatefulSet,
+				Name:       "sts",
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+			}},
+		},
+		Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+		},
+	}
+	c.enqueuePodTunnelKeyRepair(stsPod, ovnNet(1234))
+	c.enqueuePodTunnelKeyRepair(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dead",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation: "true",
+			},
+		},
+		Spec:   corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
+		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}, ovnNet(1234))
+	require.Equal(t, 2, c.repairTunnelKeyQueue.Len(), "non-alive STS pod must be enqueued, non-alive regular pod must not")
+	for range 2 {
+		key, _ := c.repairTunnelKeyQueue.Get()
+		c.repairTunnelKeyQueue.Done(key)
+	}
 }
 
 func TestResyncPodTunnelKeyOnce(t *testing.T) {
@@ -1120,14 +1159,28 @@ func TestResyncPodTunnelKeyOnce(t *testing.T) {
 			podWith("host-network", nil, corev1.PodRunning, true),
 			// terminated: must be skipped
 			podWith("terminated", nil, corev1.PodSucceeded, false),
+			// non-alive StatefulSet pod: must be enqueued (matches InitIPAM)
+			func() *corev1.Pod {
+				p := podWith("sts-0", nil, corev1.PodSucceeded, false)
+				p.OwnerReferences = []metav1.OwnerReference{{
+					Kind:       util.KindStatefulSet,
+					Name:       "sts",
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+				}}
+				return p
+			}(),
 		},
 	})
 	require.NoError(t, err)
 	c := fc.fakeController
 
 	require.NoError(t, c.resyncPodTunnelKeyOnce())
-	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "only the allocated OVN pod missing tunnel_key must be enqueued")
-	key, _ := c.repairTunnelKeyQueue.Get()
-	c.repairTunnelKeyQueue.Done(key)
-	require.Equal(t, "default/needs-repair", key)
+	require.Equal(t, 2, c.repairTunnelKeyQueue.Len(), "only the allocated OVN pods missing tunnel_key must be enqueued")
+	keys := []string{}
+	for range c.repairTunnelKeyQueue.Len() {
+		key, _ := c.repairTunnelKeyQueue.Get()
+		c.repairTunnelKeyQueue.Done(key)
+		keys = append(keys, key)
+	}
+	require.ElementsMatch(t, []string{"default/needs-repair", "default/sts-0"}, keys)
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -20,15 +20,8 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
 
-// readGauge/readCounter read a metric value without pulling the prometheus
-// testutil package (and its extra dependencies) into the test dependency tree.
-func readGauge(t *testing.T, g prometheus.Gauge) float64 {
-	t.Helper()
-	var m dto.Metric
-	require.NoError(t, g.Write(&m))
-	return m.GetGauge().GetValue()
-}
-
+// readCounter reads a metric value without pulling the prometheus testutil
+// package (and its extra dependencies) into the test dependency tree.
 func readCounter(t *testing.T, c prometheus.Counter) float64 {
 	t.Helper()
 	var m dto.Metric
@@ -1099,170 +1092,61 @@ func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
 }
 
 func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
-	ovnNet := func(tunnelKey int) []*kubeovnNet {
-		return []*kubeovnNet{{
-			Type:         providerTypeOriginal,
-			ProviderName: util.OvnProvider,
-			Subnet: &kubeovnv1.Subnet{
-				ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
-				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
-				Status:     kubeovnv1.SubnetStatus{TunnelKey: tunnelKey},
+	podWith := func(name string, annos map[string]string, phase corev1.PodPhase, hostNetwork, sts bool) *corev1.Pod {
+		p := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   "default",
+				Annotations: annos,
 			},
-			IsDefault: true,
-		}}
+			Spec:   corev1.PodSpec{HostNetwork: hostNetwork},
+			Status: corev1.PodStatus{Phase: phase},
+		}
+		if sts {
+			p.OwnerReferences = []metav1.OwnerReference{{
+				Kind:       util.KindStatefulSet,
+				Name:       "sts",
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+			}}
+		}
+		return p
 	}
-
-	missing := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "missing",
-			Namespace: "default",
-			Annotations: map[string]string{
-				util.AllocatedAnnotation: "true",
-			},
-		},
-	}
-	has := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "has",
-			Namespace: "default",
-			Annotations: map[string]string{
-				util.AllocatedAnnotation: "true",
-				util.TunnelKeyAnnotation: "1234",
-			},
-		},
-	}
-	notAllocated := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "not-allocated",
-			Namespace: "default",
-		},
+	ovnAnnotations := func(extra map[string]string) map[string]string {
+		annos := map[string]string{
+			util.AllocatedAnnotation:     "true",
+			util.LogicalSwitchAnnotation: "ovn-subnet",
+		}
+		for k, v := range extra {
+			annos[k] = v
+		}
+		return annos
 	}
 
 	fc, err := newFakeControllerWithOptions(t, nil)
 	require.NoError(t, err)
 	c := fc.fakeController
 
-	// Only the allocated OVN pod missing the annotation must be enqueued.
-	c.enqueuePodTunnelKeyRepair(missing, ovnNet(1234))
-	c.enqueuePodTunnelKeyRepair(has, ovnNet(1234))
-	c.enqueuePodTunnelKeyRepair(notAllocated, ovnNet(1234))
+	// allocated OVN pod missing tunnel_key: must be enqueued
+	c.enqueuePodTunnelKeyRepair(podWith("missing", ovnAnnotations(nil), corev1.PodRunning, false, false))
+	// already annotated: must not be enqueued
+	c.enqueuePodTunnelKeyRepair(podWith("has", ovnAnnotations(map[string]string{util.TunnelKeyAnnotation: "1234"}), corev1.PodRunning, false, false))
+	// not allocated: must not be enqueued
+	c.enqueuePodTunnelKeyRepair(podWith("not-allocated", map[string]string{util.LogicalSwitchAnnotation: "ovn-subnet"}, corev1.PodRunning, false, false))
+	// non-OVN NIC (allocated but no logical_switch): must not be enqueued
+	c.enqueuePodTunnelKeyRepair(podWith("non-ovn", map[string]string{util.AllocatedAnnotation: "true"}, corev1.PodRunning, false, false))
+	// hostNetwork: must not be enqueued
+	c.enqueuePodTunnelKeyRepair(podWith("host-network", ovnAnnotations(nil), corev1.PodRunning, true, false))
+	// terminated non-STS pod: must not be enqueued
+	c.enqueuePodTunnelKeyRepair(podWith("dead", ovnAnnotations(nil), corev1.PodSucceeded, false, false))
+	// non-alive StatefulSet pod: must be enqueued (matches InitIPAM's filter)
+	c.enqueuePodTunnelKeyRepair(podWith("sts-0", ovnAnnotations(nil), corev1.PodSucceeded, false, true))
 
-	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "only the pod missing tunnel_key must be enqueued")
-	key, _ := c.repairTunnelKeyQueue.Get()
-	c.repairTunnelKeyQueue.Done(key)
-	require.Equal(t, "default/missing", key)
-
-	// A pod whose subnet key is still 0 at init time must be enqueued too:
-	// the repair handler requeues with backoff until the key is synced by the
-	// subnet worker, so the init-before-subnet-sync ordering does not lose it.
-	c.enqueuePodTunnelKeyRepair(missing, ovnNet(0))
-	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "enqueue must be independent of the subnet key state")
-
-	// A non-alive StatefulSet pod must still be enqueued (it holds its
-	// allocated IP and will be re-scheduled), matching InitIPAM's filter;
-	// a non-alive regular pod must not.
-	stsPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sts-0",
-			Namespace: "default",
-			Annotations: map[string]string{
-				util.AllocatedAnnotation: "true",
-			},
-			OwnerReferences: []metav1.OwnerReference{{
-				Kind:       util.KindStatefulSet,
-				Name:       "sts",
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-			}},
-		},
-		Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodSucceeded,
-		},
-	}
-	c.enqueuePodTunnelKeyRepair(stsPod, ovnNet(1234))
-	c.enqueuePodTunnelKeyRepair(&corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dead",
-			Namespace: "default",
-			Annotations: map[string]string{
-				util.AllocatedAnnotation: "true",
-			},
-		},
-		Spec:   corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
-		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
-	}, ovnNet(1234))
-	require.Equal(t, 2, c.repairTunnelKeyQueue.Len(), "non-alive STS pod must be enqueued, non-alive regular pod must not")
-	for range 2 {
-		key, _ := c.repairTunnelKeyQueue.Get()
-		c.repairTunnelKeyQueue.Done(key)
-	}
-}
-
-func TestResyncPodTunnelKeyOnce(t *testing.T) {
-	subnet := &kubeovnv1.Subnet{
-		ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
-		Spec: kubeovnv1.SubnetSpec{
-			CIDRBlock: "10.0.1.0/24",
-			Protocol:  kubeovnv1.ProtocolIPv4,
-			Provider:  util.OvnProvider,
-		},
-		Status: kubeovnv1.SubnetStatus{TunnelKey: 1234},
-	}
-	podWith := func(name string, annos map[string]string, phase corev1.PodPhase, hostNetwork bool) *corev1.Pod {
-		if annos == nil {
-			annos = map[string]string{}
-		}
-		annos[util.LogicalSwitchAnnotation] = subnet.Name
-		annos[util.AllocatedAnnotation] = "true"
-		return &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        name,
-				Namespace:   "default",
-				Annotations: annos,
-			},
-			Spec: corev1.PodSpec{HostNetwork: hostNetwork},
-			Status: corev1.PodStatus{
-				Phase: phase,
-			},
-		}
-	}
-
-	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
-		Namespaces: []*corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "default"}}},
-		Subnets:    []*kubeovnv1.Subnet{subnet},
-		Pods: []*corev1.Pod{
-			// allocated, missing tunnel_key: must be enqueued
-			podWith("needs-repair", nil, corev1.PodRunning, false),
-			// allocated, already annotated: must be skipped
-			podWith("has-key", map[string]string{util.TunnelKeyAnnotation: "1234"}, corev1.PodRunning, false),
-			// hostNetwork: must be skipped
-			podWith("host-network", nil, corev1.PodRunning, true),
-			// terminated: must be skipped
-			podWith("terminated", nil, corev1.PodSucceeded, false),
-			// non-alive StatefulSet pod: must be enqueued (matches InitIPAM)
-			func() *corev1.Pod {
-				p := podWith("sts-0", nil, corev1.PodSucceeded, false)
-				p.OwnerReferences = []metav1.OwnerReference{{
-					Kind:       util.KindStatefulSet,
-					Name:       "sts",
-					APIVersion: appsv1.SchemeGroupVersion.String(),
-				}}
-				return p
-			}(),
-		},
-	})
-	require.NoError(t, err)
-	c := fc.fakeController
-
-	metricPodTunnelKeyMissing.Set(0)
-	require.NoError(t, c.resyncPodTunnelKeyOnce())
-	require.Equal(t, float64(2), readGauge(t, metricPodTunnelKeyMissing), "gauge must report the two pods missing tunnel_key")
-	require.Equal(t, 2, c.repairTunnelKeyQueue.Len(), "only the allocated OVN pods missing tunnel_key must be enqueued")
+	require.Equal(t, 2, c.repairTunnelKeyQueue.Len(), "only allocated OVN pods missing tunnel_key must be enqueued")
 	keys := []string{}
 	for range c.repairTunnelKeyQueue.Len() {
 		key, _ := c.repairTunnelKeyQueue.Get()
 		c.repairTunnelKeyQueue.Done(key)
 		keys = append(keys, key)
 	}
-	require.ElementsMatch(t, []string{"default/needs-repair", "default/sts-0"}, keys)
+	require.ElementsMatch(t, []string{"default/missing", "default/sts-0"}, keys)
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	prometheusTestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -18,6 +19,22 @@ import (
 	"github.com/kubeovn/kube-ovn/pkg/ipam"
 	"github.com/kubeovn/kube-ovn/pkg/util"
 )
+
+// readGauge/readCounter read a metric value without pulling the prometheus
+// testutil package (and its extra dependencies) into the test dependency tree.
+func readGauge(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, g.Write(&m))
+	return m.GetGauge().GetValue()
+}
+
+func readCounter(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, c.Write(&m))
+	return m.GetCounter().GetValue()
+}
 
 func TestCheckIsPodVpcNatGw(t *testing.T) {
 	tests := []struct {
@@ -1019,6 +1036,64 @@ func TestHandleRepairTunnelKey(t *testing.T) {
 	})
 }
 
+func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
+	subnets := []*kubeovnv1.Subnet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ovn-a"},
+			Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+			Status:     kubeovnv1.SubnetStatus{TunnelKey: 1234},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ovn-b"},
+			Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+			Status:     kubeovnv1.SubnetStatus{TunnelKey: 0},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multi-nic",
+			Namespace: "default",
+			Annotations: map[string]string{
+				// NIC 1: allocated on ovn-a, missing tunnel_key -> patched
+				util.AllocatedAnnotation:     "true",
+				util.LogicalSwitchAnnotation: "ovn-a",
+				// NIC 2: allocated on ovn-b whose key is not synced -> requeued, not patched
+				"net1.ovn.kubernetes.io/allocated":      "true",
+				"net1.ovn.kubernetes.io/logical_switch": "ovn-b",
+				// NIC 3: allocated but no logical_switch annotation -> skipped, never guessed
+				"net2.ovn.kubernetes.io/allocated": "true",
+				// NIC 4: has logical_switch but is NOT allocated -> skipped
+				"net3.ovn.kubernetes.io/logical_switch": "ovn-a",
+			},
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Namespaces: []*corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "default"}}},
+		Subnets:    subnets,
+		Pods:       []*corev1.Pod{pod},
+	})
+	require.NoError(t, err)
+	c := fc.fakeController
+
+	skippedBefore := readCounter(t, metricPodTunnelKeySkipped)
+	err = c.handleRepairTunnelKey("default/multi-nic")
+	require.Error(t, err, "must requeue while any allocated subnet key is not synced yet")
+
+	updated, err := c.config.KubeClient.CoreV1().Pods("default").Get(context.Background(), "multi-nic", metav1.GetOptions{})
+	require.NoError(t, err)
+	// NIC 1 must be patched even though NIC 2 is not ready (partial progress lands).
+	require.Equal(t, "1234", updated.Annotations[util.TunnelKeyAnnotation])
+	// NIC 2 must not be patched with a stale zero key.
+	_, ok := updated.Annotations["net1.ovn.kubernetes.io/tunnel_key"]
+	require.False(t, ok)
+	// NIC 4 (not allocated) must not be patched.
+	_, ok = updated.Annotations["net3.ovn.kubernetes.io/tunnel_key"]
+	require.False(t, ok)
+	// NIC 3 (no logical_switch annotation) must be skipped and counted.
+	require.Equal(t, float64(1), readCounter(t, metricPodTunnelKeySkipped)-skippedBefore)
+}
+
 func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 	ovnNet := func(tunnelKey int) []*kubeovnNet {
 		return []*kubeovnNet{{
@@ -1177,7 +1252,7 @@ func TestResyncPodTunnelKeyOnce(t *testing.T) {
 
 	metricPodTunnelKeyMissing.Set(0)
 	require.NoError(t, c.resyncPodTunnelKeyOnce())
-	require.Equal(t, float64(2), prometheusTestutil.ToFloat64(metricPodTunnelKeyMissing), "gauge must report the two pods missing tunnel_key")
+	require.Equal(t, float64(2), readGauge(t, metricPodTunnelKeyMissing), "gauge must report the two pods missing tunnel_key")
 	require.Equal(t, 2, c.repairTunnelKeyQueue.Len(), "only the allocated OVN pods missing tunnel_key must be enqueued")
 	keys := []string{}
 	for range c.repairTunnelKeyQueue.Len() {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	prometheusTestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -1174,7 +1175,9 @@ func TestResyncPodTunnelKeyOnce(t *testing.T) {
 	require.NoError(t, err)
 	c := fc.fakeController
 
+	metricPodTunnelKeyMissing.Set(0)
 	require.NoError(t, c.resyncPodTunnelKeyOnce())
+	require.Equal(t, float64(2), prometheusTestutil.ToFloat64(metricPodTunnelKeyMissing), "gauge must report the two pods missing tunnel_key")
 	require.Equal(t, 2, c.repairTunnelKeyQueue.Len(), "only the allocated OVN pods missing tunnel_key must be enqueued")
 	keys := []string{}
 	for range c.repairTunnelKeyQueue.Len() {

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -880,3 +880,201 @@ func TestTunnelKeyNotReady(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleRepairTunnelKey(t *testing.T) {
+	ovnSubnet := func(tunnelKey int) *kubeovnv1.Subnet {
+		return &kubeovnv1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
+			Spec: kubeovnv1.SubnetSpec{
+				CIDRBlock: "10.0.1.0/24",
+				Protocol:  kubeovnv1.ProtocolIPv4,
+				Provider:  util.OvnProvider,
+			},
+			Status: kubeovnv1.SubnetStatus{V4AvailableIPs: 100, TunnelKey: tunnelKey},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		subnet        *kubeovnv1.Subnet
+		wantErr       bool
+		wantAnnotated bool
+		wantValue     string
+	}{
+		{
+			name: "patches missing tunnel_key from subnet status",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "ovn-subnet",
+						util.AllocatedAnnotation:     "true",
+					},
+				},
+			},
+			subnet:        ovnSubnet(1234),
+			wantAnnotated: true,
+			wantValue:     "1234",
+		},
+		{
+			name: "leaves existing annotation untouched",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "ovn-subnet",
+						util.TunnelKeyAnnotation:     "999",
+					},
+				},
+			},
+			subnet:        ovnSubnet(1234),
+			wantAnnotated: true,
+			wantValue:     "999",
+		},
+		{
+			name: "requeues when subnet tunnel key not synced yet",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "ovn-subnet",
+						util.AllocatedAnnotation:     "true",
+					},
+				},
+			},
+			subnet:  ovnSubnet(0),
+			wantErr: true,
+		},
+		{
+			name: "skips non-ovn subnet",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "underlay-subnet",
+						util.AllocatedAnnotation:     "true",
+					},
+				},
+			},
+			subnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "underlay-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: "underlay.default"},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: 7},
+			},
+		},
+		{
+			name: "skips hostNetwork pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.LogicalSwitchAnnotation: "ovn-subnet",
+					},
+				},
+				Spec: corev1.PodSpec{HostNetwork: true},
+			},
+			subnet: ovnSubnet(1234),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				Namespaces: []*corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "default"}}},
+				Subnets:    []*kubeovnv1.Subnet{tt.subnet},
+				Pods:       []*corev1.Pod{tt.pod},
+			})
+			require.NoError(t, err)
+			c := fc.fakeController
+
+			err = c.handleRepairTunnelKey("default/test-pod")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			updated, err := c.config.KubeClient.CoreV1().Pods("default").Get(context.Background(), "test-pod", metav1.GetOptions{})
+			require.NoError(t, err)
+			if tt.wantAnnotated {
+				require.Equal(t, tt.wantValue, updated.Annotations[util.TunnelKeyAnnotation])
+			} else {
+				_, ok := updated.Annotations[util.TunnelKeyAnnotation]
+				require.False(t, ok, "tunnel_key annotation must not be added")
+			}
+		})
+	}
+
+	t.Run("pod not found is a no-op", func(t *testing.T) {
+		fc, err := newFakeControllerWithOptions(t, nil)
+		require.NoError(t, err)
+		require.NoError(t, fc.fakeController.handleRepairTunnelKey("default/does-not-exist"))
+	})
+}
+
+func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
+	ovnNet := func(tunnelKey int) []*kubeovnNet {
+		return []*kubeovnNet{{
+			Type:         providerTypeOriginal,
+			ProviderName: util.OvnProvider,
+			Subnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: tunnelKey},
+			},
+			IsDefault: true,
+		}}
+	}
+
+	missing := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "missing",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation: "true",
+			},
+		},
+	}
+	has := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "has",
+			Namespace: "default",
+			Annotations: map[string]string{
+				util.AllocatedAnnotation: "true",
+				util.TunnelKeyAnnotation: "1234",
+			},
+		},
+	}
+	notAllocated := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "not-allocated",
+			Namespace: "default",
+		},
+	}
+
+	fc, err := newFakeControllerWithOptions(t, nil)
+	require.NoError(t, err)
+	c := fc.fakeController
+
+	// Only the allocated OVN pod missing the annotation must be enqueued.
+	c.enqueuePodTunnelKeyRepair(missing, ovnNet(1234))
+	c.enqueuePodTunnelKeyRepair(has, ovnNet(1234))
+	c.enqueuePodTunnelKeyRepair(notAllocated, ovnNet(1234))
+
+	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "only the pod missing tunnel_key must be enqueued")
+	key, _ := c.repairTunnelKeyQueue.Get()
+	c.repairTunnelKeyQueue.Done(key)
+	require.Equal(t, "default/missing", key)
+
+	// A pod whose subnet key is still 0 at init time must be enqueued too:
+	// the repair handler requeues with backoff until the key is synced by the
+	// subnet worker, so the init-before-subnet-sync ordering does not lose it.
+	c.enqueuePodTunnelKeyRepair(missing, ovnNet(0))
+	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "enqueue must be independent of the subnet key state")
+}

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1078,3 +1078,56 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 	c.enqueuePodTunnelKeyRepair(missing, ovnNet(0))
 	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "enqueue must be independent of the subnet key state")
 }
+
+func TestResyncPodTunnelKeyOnce(t *testing.T) {
+	subnet := &kubeovnv1.Subnet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ovn-subnet"},
+		Spec: kubeovnv1.SubnetSpec{
+			CIDRBlock: "10.0.1.0/24",
+			Protocol:  kubeovnv1.ProtocolIPv4,
+			Provider:  util.OvnProvider,
+		},
+		Status: kubeovnv1.SubnetStatus{TunnelKey: 1234},
+	}
+	podWith := func(name string, annos map[string]string, phase corev1.PodPhase, hostNetwork bool) *corev1.Pod {
+		if annos == nil {
+			annos = map[string]string{}
+		}
+		annos[util.LogicalSwitchAnnotation] = subnet.Name
+		annos[util.AllocatedAnnotation] = "true"
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   "default",
+				Annotations: annos,
+			},
+			Spec: corev1.PodSpec{HostNetwork: hostNetwork},
+			Status: corev1.PodStatus{
+				Phase: phase,
+			},
+		}
+	}
+
+	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+		Namespaces: []*corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "default"}}},
+		Subnets:    []*kubeovnv1.Subnet{subnet},
+		Pods: []*corev1.Pod{
+			// allocated, missing tunnel_key: must be enqueued
+			podWith("needs-repair", nil, corev1.PodRunning, false),
+			// allocated, already annotated: must be skipped
+			podWith("has-key", map[string]string{util.TunnelKeyAnnotation: "1234"}, corev1.PodRunning, false),
+			// hostNetwork: must be skipped
+			podWith("host-network", nil, corev1.PodRunning, true),
+			// terminated: must be skipped
+			podWith("terminated", nil, corev1.PodSucceeded, false),
+		},
+	})
+	require.NoError(t, err)
+	c := fc.fakeController
+
+	require.NoError(t, c.resyncPodTunnelKeyOnce())
+	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "only the allocated OVN pod missing tunnel_key must be enqueued")
+	key, _ := c.repairTunnelKeyQueue.Get()
+	c.repairTunnelKeyQueue.Done(key)
+	require.Equal(t, "default/needs-repair", key)
+}

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -739,6 +739,12 @@ func TestReconcileAllocateSubnets_gatedOnTunnelKey(t *testing.T) {
 	_, err = c.reconcileAllocateSubnets(pod, podNets)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "tunnel key not observed")
+
+	persisted, err := c.config.KubeClient.CoreV1().Pods("default").Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotEqual(t, "true", persisted.Annotations[util.AllocatedAnnotation])
+	require.Empty(t, persisted.Annotations[util.IPAddressAnnotation])
+	require.Empty(t, persisted.Annotations[util.TunnelKeyAnnotation])
 }
 
 // TestReconcileAllocateSubnets_allowedWhenTunnelKeySynced is the happy-path counterpart of the gate
@@ -788,6 +794,15 @@ func TestReconcileAllocateSubnets_allowedWhenTunnelKeySynced(t *testing.T) {
 	require.NotNil(t, allocated)
 	tunnelKeyKey := fmt.Sprintf(util.TunnelKeyAnnotationTemplate, podNets[0].ProviderName)
 	require.Equal(t, "1234", allocated.Annotations[tunnelKeyKey])
+	require.Equal(t, "true", allocated.Annotations[util.AllocatedAnnotation])
+	require.NotEmpty(t, allocated.Annotations[util.IPAddressAnnotation])
+	require.Equal(t, subnet.Name, allocated.Annotations[util.LogicalSwitchAnnotation])
+
+	persisted, err := c.config.KubeClient.CoreV1().Pods("default").Get(context.Background(), pod.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, allocated.Annotations[util.IPAddressAnnotation], persisted.Annotations[util.IPAddressAnnotation])
+	require.Equal(t, "1234", persisted.Annotations[util.TunnelKeyAnnotation])
+	require.Equal(t, "true", persisted.Annotations[util.AllocatedAnnotation])
 }
 
 func TestReconcileAllocateSubnetsUsesResolvedSubnetForTunnelKey(t *testing.T) {
@@ -1424,29 +1439,4 @@ func TestEnqueuePodTunnelKeyRepair(t *testing.T) {
 		"default/vlan-stale",
 		"default/sts-0",
 	}, keys)
-}
-
-func TestHandleAddOrUpdatePodEnqueuesTunnelKeyRepairBeforeValidation(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "legacy-pod",
-			Namespace: "default",
-			Annotations: map[string]string{
-				util.AllocatedAnnotation:     "true",
-				util.LogicalSwitchAnnotation: "ovn-subnet",
-				util.IPAddressAnnotation:     "not-an-ip",
-			},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{Pods: []*corev1.Pod{pod}})
-	require.NoError(t, err)
-	c := fc.fakeController
-
-	err = c.handleAddOrUpdatePod("default/legacy-pod")
-	require.Error(t, err, "invalid network annotation must still stop normal pod reconciliation")
-	require.Equal(t, 1, c.repairTunnelKeyQueue.Len(), "repair must be enqueued before validation returns")
-	key, _ := c.repairTunnelKeyQueue.Get()
-	c.repairTunnelKeyQueue.Done(key)
-	require.Equal(t, "default/legacy-pod", key)
 }

--- a/pkg/controller/pod_test.go
+++ b/pkg/controller/pod_test.go
@@ -1344,7 +1344,7 @@ func TestHandleRepairTunnelKeyMultiNIC(t *testing.T) {
 	require.Equal(t, float64(1), readCounter(t, metricPodTunnelKeySkipped)-skippedBefore)
 }
 
-func TestPodDefaultTunnelKeyPolicySatisfied(t *testing.T) {
+func TestCanSkipDefaultTunnelKeyRepair(t *testing.T) {
 	fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
 		Subnets: []*kubeovnv1.Subnet{
 			{
@@ -1377,7 +1377,7 @@ func TestPodDefaultTunnelKeyPolicySatisfied(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}}
-			require.Equal(t, tt.want, c.podDefaultTunnelKeyPolicySatisfied(pod))
+			require.Equal(t, tt.want, c.canSkipDefaultTunnelKeyRepair(pod))
 		})
 	}
 }

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1978,8 +1978,8 @@ func isOvnSubnet(subnet *kubeovnv1.Subnet) bool {
 }
 
 // isOvnVpcSubnet reports whether the subnet participates in the VPC tunnel-key
-// guarantee. OVN vlan/underlay subnets still use OVN logical switches, but they
-// are not VPC overlay subnets and keep the default TunnelKey value.
+// guarantee. It includes default and custom VPCs; Vlan is the only VPC/underlay
+// discriminator after the OVN-provider check.
 func isOvnVpcSubnet(subnet *kubeovnv1.Subnet) bool {
 	return isOvnSubnet(subnet) && subnet.Spec.Vlan == ""
 }

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -585,6 +585,9 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	}
 
 	if !isOvnSubnet(subnet) {
+		if err := c.reconcileSubnetTunnelKey(subnet); err != nil {
+			return err
+		}
 		// subnet provider is not ovn, and vpc is empty, should not reconcile
 		if err = c.patchSubnetStatus(subnet, "SetNonOvnSubnetSuccess", ""); err != nil {
 			klog.Error(err)
@@ -705,11 +708,10 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 		}
 	}
 
-	// Sync tunnel_key from OVN SB into subnet status before any path that can mark the subnet
-	// Ready. reconcileSubnet below sets Ready for centralized-gateway subnets, so the sync must
-	// run first to guarantee that Ready implies a valid TunnelKey. The SB Datapath_Binding that
-	// carries the tunnel key is created by northd once the NB logical switch exists, so this must
-	// run after CreateLogicalSwitch above.
+	// Only non-vlan OVN VPC subnets require tunnel_key. Sync it from OVN SB before any path
+	// that can mark such a subnet Ready; every other subnet type keeps the default zero value.
+	// reconcileSubnet below sets Ready for centralized-gateway subnets, so this must run after
+	// CreateLogicalSwitch and before Ready to guarantee a valid TunnelKey for VPC subnets.
 	//
 	// Trade-off: on a brand-new subnet's first reconcile, northd may not have created the
 	// Datapath_Binding yet, so syncSubnetTunnelKey fails and we requeue. DHCP/LB were already
@@ -717,14 +719,12 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	// the subnet Ready is delayed by one requeue cycle. A new subnet has no pods yet, so there is
 	// no side effect on pod networking.
 	//
-	// Known limitation: if the Datapath_Binding never appears (a genuine NB/SB desync, which the
-	// mandatory-VNI invariant says should not happen), the subnet stays NotReady and requeues,
+	// Known limitation: if the Datapath_Binding never appears for an OVN VPC subnet (a genuine
+	// NB/SB desync, which the mandatory-VNI invariant says should not happen), it stays NotReady and requeues,
 	// logging the sync error each cycle. That per-cycle error log is the diagnosis signal.
-	if isOvnSubnet(subnet) && !isValidTunnelKey(subnet.Status.TunnelKey) {
-		if err := c.syncSubnetTunnelKey(subnet); err != nil {
-			klog.Errorf("failed to sync tunnel key for subnet %s: %v", subnet.Name, err)
-			return err
-		}
+	if err := c.reconcileSubnetTunnelKey(subnet); err != nil {
+		klog.Errorf("failed to reconcile tunnel key for subnet %s: %v", subnet.Name, err)
+		return err
 	}
 
 	if err := c.reconcileSubnet(subnet); err != nil {
@@ -1975,6 +1975,13 @@ func (c *Controller) releaseMcastQuerierIP(subnet *kubeovnv1.Subnet) (bool, erro
 
 func isOvnSubnet(subnet *kubeovnv1.Subnet) bool {
 	return subnet != nil && util.IsOvnProvider(subnet.Spec.Provider)
+}
+
+// isOvnVpcSubnet reports whether the subnet participates in the VPC tunnel-key
+// guarantee. OVN vlan/underlay subnets still use OVN logical switches, but they
+// are not VPC overlay subnets and keep the default TunnelKey value.
+func isOvnVpcSubnet(subnet *kubeovnv1.Subnet) bool {
+	return isOvnSubnet(subnet) && subnet.Spec.Vlan == ""
 }
 
 func formatExcludeIPRanges(subnet *kubeovnv1.Subnet) {
@@ -3286,6 +3293,19 @@ func (c *Controller) syncNadMacvlanMasterAnnotation(subnet *kubeovnv1.Subnet) er
 	return nil
 }
 
+func (c *Controller) reconcileSubnetTunnelKey(subnet *kubeovnv1.Subnet) error {
+	if isOvnVpcSubnet(subnet) {
+		if isValidTunnelKey(subnet.Status.TunnelKey) {
+			return nil
+		}
+		return c.syncSubnetTunnelKey(subnet)
+	}
+	if subnet.Status.TunnelKey == 0 {
+		return nil
+	}
+	return c.patchSubnetTunnelKey(subnet, 0)
+}
+
 func (c *Controller) syncSubnetTunnelKey(subnet *kubeovnv1.Subnet) error {
 	tunnelKey, err := c.OVNSbClient.GetLogicalSwitchTunnelKey(subnet.Name)
 	if err != nil {
@@ -3299,6 +3319,14 @@ func (c *Controller) syncSubnetTunnelKey(subnet *kubeovnv1.Subnet) error {
 		return err
 	}
 
+	if err := c.patchSubnetTunnelKey(subnet, tunnelKey); err != nil {
+		return err
+	}
+	klog.Infof("synced tunnel key %d for subnet %s", tunnelKey, subnet.Name)
+	return nil
+}
+
+func (c *Controller) patchSubnetTunnelKey(subnet *kubeovnv1.Subnet, tunnelKey int) error {
 	patch := []byte(fmt.Sprintf(`{"status":{"tunnelKey":%d}}`, tunnelKey))
 	if _, err := c.config.KubeOvnClient.KubeovnV1().Subnets().Patch(context.Background(), subnet.Name, types.MergePatchType, patch, metav1.PatchOptions{}, "status"); err != nil {
 		klog.Errorf("failed to patch tunnel key for subnet %s: %v", subnet.Name, err)
@@ -3308,6 +3336,5 @@ func (c *Controller) syncSubnetTunnelKey(subnet *kubeovnv1.Subnet) error {
 	// reconcile (which serialize the whole status) stay consistent, and so correctness does not
 	// silently depend on the tunnelKey json omitempty tag.
 	subnet.Status.TunnelKey = tunnelKey
-	klog.Infof("synced tunnel key %d for subnet %s", tunnelKey, subnet.Name)
 	return nil
 }

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -1977,13 +1977,6 @@ func isOvnSubnet(subnet *kubeovnv1.Subnet) bool {
 	return subnet != nil && util.IsOvnProvider(subnet.Spec.Provider)
 }
 
-// isOvnVpcSubnet reports whether the subnet participates in the VPC tunnel-key
-// guarantee. It includes default and custom VPCs; Vlan is the only VPC/underlay
-// discriminator after the OVN-provider check.
-func isOvnVpcSubnet(subnet *kubeovnv1.Subnet) bool {
-	return isOvnSubnet(subnet) && subnet.Spec.Vlan == ""
-}
-
 func formatExcludeIPRanges(subnet *kubeovnv1.Subnet) {
 	var excludeIPs []string
 	mapIPs := make(map[string]*ipam.IPRange, len(subnet.Spec.ExcludeIps))
@@ -3294,8 +3287,8 @@ func (c *Controller) syncNadMacvlanMasterAnnotation(subnet *kubeovnv1.Subnet) er
 }
 
 func (c *Controller) reconcileSubnetTunnelKey(subnet *kubeovnv1.Subnet) error {
-	if isOvnVpcSubnet(subnet) {
-		if isValidTunnelKey(subnet.Status.TunnelKey) {
+	if util.IsOvnVpcSubnet(subnet) {
+		if util.IsValidTunnelKey(subnet.Status.TunnelKey) {
 			return nil
 		}
 		return c.syncSubnetTunnelKey(subnet)
@@ -3313,7 +3306,7 @@ func (c *Controller) syncSubnetTunnelKey(subnet *kubeovnv1.Subnet) error {
 		klog.Error(err)
 		return err
 	}
-	if !isValidTunnelKey(tunnelKey) {
+	if !util.IsValidTunnelKey(tunnelKey) {
 		err := fmt.Errorf("invalid tunnel key %d for logical switch %s", tunnelKey, subnet.Name)
 		klog.Error(err)
 		return err

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -707,7 +707,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 
 	// Sync tunnel_key from OVN SB into subnet status before any path that can mark the subnet
 	// Ready. reconcileSubnet below sets Ready for centralized-gateway subnets, so the sync must
-	// run first to guarantee that Ready implies a non-zero TunnelKey. The SB Datapath_Binding that
+	// run first to guarantee that Ready implies a valid TunnelKey. The SB Datapath_Binding that
 	// carries the tunnel key is created by northd once the NB logical switch exists, so this must
 	// run after CreateLogicalSwitch above.
 	//
@@ -720,7 +720,7 @@ func (c *Controller) handleAddOrUpdateSubnet(key string) error {
 	// Known limitation: if the Datapath_Binding never appears (a genuine NB/SB desync, which the
 	// mandatory-VNI invariant says should not happen), the subnet stays NotReady and requeues,
 	// logging the sync error each cycle. That per-cycle error log is the diagnosis signal.
-	if isOvnSubnet(subnet) && subnet.Status.TunnelKey == 0 {
+	if isOvnSubnet(subnet) && !isValidTunnelKey(subnet.Status.TunnelKey) {
 		if err := c.syncSubnetTunnelKey(subnet); err != nil {
 			klog.Errorf("failed to sync tunnel key for subnet %s: %v", subnet.Name, err)
 			return err
@@ -3290,6 +3290,11 @@ func (c *Controller) syncSubnetTunnelKey(subnet *kubeovnv1.Subnet) error {
 	tunnelKey, err := c.OVNSbClient.GetLogicalSwitchTunnelKey(subnet.Name)
 	if err != nil {
 		err = fmt.Errorf("failed to get tunnel key for logical switch %s: %w", subnet.Name, err)
+		klog.Error(err)
+		return err
+	}
+	if !isValidTunnelKey(tunnelKey) {
+		err := fmt.Errorf("invalid tunnel key %d for logical switch %s", tunnelKey, subnet.Name)
 		klog.Error(err)
 		return err
 	}

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	"github.com/kubeovn/kube-ovn/pkg/ovsdb/ovnnb"
@@ -708,6 +709,120 @@ func Test_syncSubnetTunnelKey(t *testing.T) {
 			err := ctrl.syncSubnetTunnelKey(subnet)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid tunnel key")
+		})
+	}
+}
+
+func Test_reconcileSubnetTunnelKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		subnet     *kubeovnv1.Subnet
+		sbKey      *int
+		wantStatus int
+	}{
+		{
+			name: "syncs invalid OVN VPC key",
+			subnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "vpc-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+			},
+			sbKey:      ptr.To(77),
+			wantStatus: 77,
+		},
+		{
+			name: "keeps valid OVN VPC key",
+			subnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "vpc-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: 88},
+			},
+			wantStatus: 88,
+		},
+		{
+			name: "clears OVN vlan underlay key",
+			subnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: 99},
+			},
+			wantStatus: 0,
+		},
+		{
+			name: "clears non-OVN provider key",
+			subnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{Name: "ipam-only-subnet"},
+				Spec:       kubeovnv1.SubnetSpec{Provider: "net1.default"},
+				Status:     kubeovnv1.SubnetStatus{TunnelKey: 99},
+			},
+			wantStatus: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc, err := newFakeControllerWithOptions(t, &FakeControllerOptions{
+				Subnets: []*kubeovnv1.Subnet{tt.subnet},
+			})
+			require.NoError(t, err)
+			if tt.sbKey != nil {
+				fc.mockOvnSbClient.EXPECT().GetLogicalSwitchTunnelKey(tt.subnet.Name).
+					Return(*tt.sbKey, nil)
+			}
+
+			err = fc.fakeController.reconcileSubnetTunnelKey(tt.subnet)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, tt.subnet.Status.TunnelKey)
+
+			updated, err := fc.fakeController.config.KubeOvnClient.KubeovnV1().Subnets().Get(
+				context.Background(), tt.subnet.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, updated.Status.TunnelKey)
+		})
+	}
+}
+
+func Test_isOvnVpcSubnet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		subnet *kubeovnv1.Subnet
+		want   bool
+	}{
+		{name: "nil", subnet: nil, want: false},
+		{
+			name: "default provider non-vlan subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: ""},
+			},
+			want: true,
+		},
+		{
+			name: "explicit OVN non-vlan subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+			},
+			want: true,
+		},
+		{
+			name: "OVN vlan underlay subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"},
+			},
+			want: false,
+		},
+		{
+			name: "non-OVN provider",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: "external.provider"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isOvnVpcSubnet(tc.subnet))
 		})
 	}
 }

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -701,7 +701,7 @@ func Test_syncSubnetTunnelKey(t *testing.T) {
 		require.Contains(t, err.Error(), "sb unavailable")
 	})
 
-	for _, tunnelKey := range []int{0, -1, maxTunnelKey + 1} {
+	for _, tunnelKey := range []int{0, -1, util.MaxTunnelKey + 1} {
 		t.Run(fmt.Sprintf("rejects invalid tunnel key %d", tunnelKey), func(t *testing.T) {
 			fc.mockOvnSbClient.EXPECT().GetLogicalSwitchTunnelKey("test-ovn-subnet").
 				Return(tunnelKey, nil)
@@ -777,66 +777,6 @@ func Test_reconcileSubnetTunnelKey(t *testing.T) {
 				context.Background(), tt.subnet.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 			require.Equal(t, tt.wantStatus, updated.Status.TunnelKey)
-		})
-	}
-}
-
-func Test_isOvnVpcSubnet(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name   string
-		subnet *kubeovnv1.Subnet
-		want   bool
-	}{
-		{name: "nil", subnet: nil, want: false},
-		{
-			name: "implicit default VPC non-vlan subnet",
-			subnet: &kubeovnv1.Subnet{
-				Spec: kubeovnv1.SubnetSpec{Provider: ""},
-			},
-			want: true,
-		},
-		{
-			name: "default cluster router VPC non-vlan subnet",
-			subnet: &kubeovnv1.Subnet{
-				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vpc: util.DefaultVpc},
-			},
-			want: true,
-		},
-		{
-			name: "custom VPC non-vlan subnet",
-			subnet: &kubeovnv1.Subnet{
-				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vpc: "custom-vpc"},
-			},
-			want: true,
-		},
-		{
-			name: "default VPC vlan underlay subnet",
-			subnet: &kubeovnv1.Subnet{
-				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vpc: util.DefaultVpc, Vlan: "vlan-a"},
-			},
-			want: false,
-		},
-		{
-			name: "custom VPC vlan underlay subnet",
-			subnet: &kubeovnv1.Subnet{
-				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vpc: "custom-vpc", Vlan: "vlan-a"},
-			},
-			want: false,
-		},
-		{
-			name: "non-OVN provider",
-			subnet: &kubeovnv1.Subnet{
-				Spec: kubeovnv1.SubnetSpec{Provider: "external.provider"},
-			},
-			want: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, isOvnVpcSubnet(tc.subnet))
 		})
 	}
 }

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -791,23 +791,37 @@ func Test_isOvnVpcSubnet(t *testing.T) {
 	}{
 		{name: "nil", subnet: nil, want: false},
 		{
-			name: "default provider non-vlan subnet",
+			name: "implicit default VPC non-vlan subnet",
 			subnet: &kubeovnv1.Subnet{
 				Spec: kubeovnv1.SubnetSpec{Provider: ""},
 			},
 			want: true,
 		},
 		{
-			name: "explicit OVN non-vlan subnet",
+			name: "default cluster router VPC non-vlan subnet",
 			subnet: &kubeovnv1.Subnet{
-				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vpc: util.DefaultVpc},
 			},
 			want: true,
 		},
 		{
-			name: "OVN vlan underlay subnet",
+			name: "custom VPC non-vlan subnet",
 			subnet: &kubeovnv1.Subnet{
-				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"},
+				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vpc: "custom-vpc"},
+			},
+			want: true,
+		},
+		{
+			name: "default VPC vlan underlay subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vpc: util.DefaultVpc, Vlan: "vlan-a"},
+			},
+			want: false,
+		},
+		{
+			name: "custom VPC vlan underlay subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vpc: "custom-vpc", Vlan: "vlan-a"},
 			},
 			want: false,
 		},

--- a/pkg/controller/subnet_test.go
+++ b/pkg/controller/subnet_test.go
@@ -699,6 +699,17 @@ func Test_syncSubnetTunnelKey(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "sb unavailable")
 	})
+
+	for _, tunnelKey := range []int{0, -1, maxTunnelKey + 1} {
+		t.Run(fmt.Sprintf("rejects invalid tunnel key %d", tunnelKey), func(t *testing.T) {
+			fc.mockOvnSbClient.EXPECT().GetLogicalSwitchTunnelKey("test-ovn-subnet").
+				Return(tunnelKey, nil)
+
+			err := ctrl.syncSubnetTunnelKey(subnet)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid tunnel key")
+		})
+	}
 }
 
 func Test_isOvnSubnet(t *testing.T) {

--- a/pkg/controller/tunnel_key_metrics.go
+++ b/pkg/controller/tunnel_key_metrics.go
@@ -17,8 +17,9 @@ var (
 
 	// metricPodTunnelKeySkipped counts pods the tunnel_key repair could not
 	// process because the subnet named by their logical_switch annotation no
-	// longer exists. Non-OVN NICs (no logical_switch) are not counted: they
-	// legitimately never get a tunnel_key.
+	// longer exists. Providers without a logical_switch annotation (subnets
+	// whose provider is not ovn, i.e. kube-ovn as IPAM only) are not counted:
+	// they legitimately never get a tunnel_key.
 	metricPodTunnelKeySkipped = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "pod_tunnel_key_repair_skipped_total",
 		Help: "Total number of tunnel_key repairs skipped because the logical_switch subnet no longer exists.",

--- a/pkg/controller/tunnel_key_metrics.go
+++ b/pkg/controller/tunnel_key_metrics.go
@@ -15,8 +15,8 @@ var (
 		Help: "Total number of annotation patches that wrote one or more tunnel_key (VNI) annotations; a pod with several OVN NICs can be patched more than once.",
 	})
 
-	// metricPodTunnelKeySkipped counts pods the tunnel_key repair could not
-	// process because the subnet named by their logical_switch annotation no
+	// metricPodTunnelKeySkipped counts provider repairs that could not
+	// proceed because the subnet named by their logical_switch annotation no
 	// longer exists. Providers without a logical_switch annotation (subnets
 	// whose provider is not ovn, i.e. kube-ovn as IPAM only) are not counted:
 	// they legitimately never get a tunnel_key.

--- a/pkg/controller/tunnel_key_metrics.go
+++ b/pkg/controller/tunnel_key_metrics.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// metricPodTunnelKeyMissing is the current number of allocated OVN pods
+	// missing the tunnel_key (VNI) annotation, as measured by the periodic
+	// resync (resyncPodTunnelKeyOnce). A non-zero value means Cilium would
+	// fall back to the non-VPC endpoint scheme for those pods until the repair
+	// worker patches them.
+	metricPodTunnelKeyMissing = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "pod_tunnel_key_missing",
+		Help: "Number of allocated OVN pods missing the tunnel_key (VNI) annotation, measured by the periodic tunnel_key resync.",
+	})
+
+	// metricPodTunnelKeyRepaired counts successful tunnel_key annotation
+	// patches, so repair activity for the legacy-pod backfill is observable.
+	metricPodTunnelKeyRepaired = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pod_tunnel_key_repair_total",
+		Help: "Total number of pods whose missing tunnel_key (VNI) annotation was repaired.",
+	})
+
+	// metricPodTunnelKeySkipped counts pods the tunnel_key repair could not
+	// process because their networks (NAD / default subnet) could not be
+	// resolved. Such pods are otherwise silently skipped: InitIPAM continues,
+	// the resync waits for the next tick.
+	metricPodTunnelKeySkipped = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pod_tunnel_key_repair_skipped_total",
+		Help: "Total number of pods skipped by the tunnel_key repair because their networks could not be resolved.",
+	})
+)
+
+func registerTunnelKeyMetrics() {
+	metrics.Registry.MustRegister(metricPodTunnelKeyMissing)
+	metrics.Registry.MustRegister(metricPodTunnelKeyRepaired)
+	metrics.Registry.MustRegister(metricPodTunnelKeySkipped)
+}

--- a/pkg/controller/tunnel_key_metrics.go
+++ b/pkg/controller/tunnel_key_metrics.go
@@ -8,12 +8,12 @@ import (
 var (
 	// metricPodTunnelKeyMissing is the current number of allocated OVN pods
 	// missing the tunnel_key (VNI) annotation, as measured by the periodic
-	// resync (resyncPodTunnelKeyOnce). A non-zero value means Cilium would
-	// fall back to the non-VPC endpoint scheme for those pods until the repair
-	// worker patches them.
+	// resync (resyncPodTunnelKeyOnce) during the post-start backfill window.
+	// A non-zero value means Cilium would fall back to the non-VPC endpoint
+	// scheme for those pods until the repair worker patches them.
 	metricPodTunnelKeyMissing = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "pod_tunnel_key_missing",
-		Help: "Number of allocated OVN pods missing the tunnel_key (VNI) annotation, measured by the periodic tunnel_key resync.",
+		Help: "Number of allocated OVN pods missing the tunnel_key (VNI) annotation, measured by the periodic tunnel_key resync during the post-start backfill window.",
 	})
 
 	// metricPodTunnelKeyRepaired counts successful tunnel_key annotation

--- a/pkg/controller/tunnel_key_metrics.go
+++ b/pkg/controller/tunnel_key_metrics.go
@@ -7,19 +7,19 @@ import (
 
 var (
 	// metricPodTunnelKeyRepairPatches counts successful annotation patches
-	// that wrote one or more tunnel_key (VNI) annotations. It counts patch
-	// calls, not pods: a pod with several OVN NICs can be patched more than
-	// once (partial progress when another NIC's subnet key is not synced yet).
+	// that added, corrected or removed one or more tunnel_key (VNI) annotations.
+	// It counts patch calls, not pods: a multi-NIC pod can be patched more than
+	// once when another VPC subnet key is not ready yet.
 	metricPodTunnelKeyRepairPatches = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "pod_tunnel_key_repair_patch_total",
-		Help: "Total number of annotation patches that wrote one or more tunnel_key (VNI) annotations; a pod with several OVN NICs can be patched more than once.",
+		Help: "Total number of annotation patches that added, corrected or removed one or more tunnel_key (VNI) annotations; a multi-NIC pod can be patched more than once.",
 	})
 
 	// metricPodTunnelKeySkipped counts provider repairs that could not
 	// proceed because the subnet named by their logical_switch annotation no
-	// longer exists. Providers without a logical_switch annotation (subnets
-	// whose provider is not ovn, i.e. kube-ovn as IPAM only) are not counted:
-	// they legitimately never get a tunnel_key.
+	// longer exists. Providers without logical_switch (kube-ovn as IPAM only)
+	// and OVN vlan/underlay subnets are not counted: they legitimately keep
+	// the default tunnel key.
 	metricPodTunnelKeySkipped = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "pod_tunnel_key_repair_skipped_total",
 		Help: "Total number of tunnel_key repairs skipped because the logical_switch subnet no longer exists.",

--- a/pkg/controller/tunnel_key_metrics.go
+++ b/pkg/controller/tunnel_key_metrics.go
@@ -6,35 +6,26 @@ import (
 )
 
 var (
-	// metricPodTunnelKeyMissing is the current number of allocated OVN pods
-	// missing the tunnel_key (VNI) annotation, as measured by the periodic
-	// resync (resyncPodTunnelKeyOnce) during the post-start backfill window.
-	// A non-zero value means Cilium would fall back to the non-VPC endpoint
-	// scheme for those pods until the repair worker patches them.
-	metricPodTunnelKeyMissing = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "pod_tunnel_key_missing",
-		Help: "Number of allocated OVN pods missing the tunnel_key (VNI) annotation, measured by the periodic tunnel_key resync during the post-start backfill window.",
-	})
-
-	// metricPodTunnelKeyRepaired counts successful tunnel_key annotation
-	// patches, so repair activity for the legacy-pod backfill is observable.
-	metricPodTunnelKeyRepaired = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pod_tunnel_key_repair_total",
-		Help: "Total number of pods whose missing tunnel_key (VNI) annotation was repaired.",
+	// metricPodTunnelKeyRepairPatches counts successful annotation patches
+	// that wrote one or more tunnel_key (VNI) annotations. It counts patch
+	// calls, not pods: a pod with several OVN NICs can be patched more than
+	// once (partial progress when another NIC's subnet key is not synced yet).
+	metricPodTunnelKeyRepairPatches = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pod_tunnel_key_repair_patch_total",
+		Help: "Total number of annotation patches that wrote one or more tunnel_key (VNI) annotations; a pod with several OVN NICs can be patched more than once.",
 	})
 
 	// metricPodTunnelKeySkipped counts pods the tunnel_key repair could not
-	// process because their networks (NAD / default subnet) could not be
-	// resolved. Such pods are otherwise silently skipped: InitIPAM continues,
-	// the resync waits for the next tick.
+	// process because the subnet named by their logical_switch annotation no
+	// longer exists. Non-OVN NICs (no logical_switch) are not counted: they
+	// legitimately never get a tunnel_key.
 	metricPodTunnelKeySkipped = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "pod_tunnel_key_repair_skipped_total",
-		Help: "Total number of pods skipped by the tunnel_key repair because their networks could not be resolved.",
+		Help: "Total number of tunnel_key repairs skipped because the logical_switch subnet no longer exists.",
 	})
 )
 
 func registerTunnelKeyMetrics() {
-	metrics.Registry.MustRegister(metricPodTunnelKeyMissing)
-	metrics.Registry.MustRegister(metricPodTunnelKeyRepaired)
+	metrics.Registry.MustRegister(metricPodTunnelKeyRepairPatches)
 	metrics.Registry.MustRegister(metricPodTunnelKeySkipped)
 }

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -46,6 +46,22 @@ func createCniServerHandler(config *Configuration, controller *Controller) *cniS
 	return csh
 }
 
+func (csh cniServerHandler) podTunnelKeyReady(pod *v1.Pod, provider string) (bool, error) {
+	lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
+	if lsName == "" {
+		return true, nil
+	}
+	subnet, err := csh.Controller.subnetsLister.Get(lsName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get subnet %s: %w", lsName, err)
+	}
+	if !util.IsOvnVpcSubnet(subnet) {
+		return true, nil
+	}
+	tunnelKey, err := strconv.Atoi(pod.Annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)])
+	return err == nil && util.IsValidTunnelKey(tunnelKey) && tunnelKey == subnet.Status.TunnelKey, nil
+}
+
 func (csh cniServerHandler) providerExists(provider string) (*kubeovnv1.Subnet, bool) {
 	if util.IsOvnProvider(provider) {
 		return nil, true
@@ -117,6 +133,13 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 			// wait controller assign an address
 			cniWaitAddressResult.WithLabelValues(nodeName).Inc()
 			time.Sleep(1 * time.Second)
+			continue
+		}
+		tunnelKeyReady, err := csh.podTunnelKeyReady(pod, podRequest.Provider)
+		if err != nil || !tunnelKeyReady {
+			klog.V(3).Infof("wait tunnel key for pod %s/%s provider %s: %v", podRequest.PodNamespace, podRequest.PodName, podRequest.Provider, err)
+			cniWaitTunnelKeyResult.WithLabelValues(nodeName).Inc()
+			time.Sleep(time.Second)
 			continue
 		}
 		ip = pod.Annotations[fmt.Sprintf(util.IPAddressAnnotationTemplate, podRequest.Provider)]
@@ -203,6 +226,17 @@ func (csh cniServerHandler) handleAdd(req *restful.Request, resp *restful.Respon
 		err := fmt.Errorf("no address allocated to pod %s/%s provider %s, please see kube-ovn-controller logs to find errors", pod.Namespace, pod.Name, podRequest.Provider)
 		klog.Error(err)
 		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: err.Error()}); err != nil {
+			klog.Errorf("failed to write response, %v", err)
+		}
+		return
+	}
+	if tunnelKeyReady, err := csh.podTunnelKeyReady(pod, podRequest.Provider); err != nil || !tunnelKeyReady {
+		errMsg := fmt.Errorf("tunnel key is not ready for pod %s/%s provider %s", pod.Namespace, pod.Name, podRequest.Provider)
+		if err != nil {
+			errMsg = fmt.Errorf("%w: %w", errMsg, err)
+		}
+		klog.Error(errMsg)
+		if err := resp.WriteHeaderAndEntity(http.StatusInternalServerError, request.CniResponse{Err: errMsg.Error()}); err != nil {
 			klog.Errorf("failed to write response, %v", err)
 		}
 		return

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -49,20 +49,16 @@ func createCniServerHandler(config *Configuration, controller *Controller) *cniS
 func (csh cniServerHandler) podTunnelKeyReady(pod *v1.Pod, provider string) (bool, error) {
 	lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
 	if lsName == "" {
-		// An allocated OVN provider must identify its logical switch before CNI
-		// can decide whether the VPC key is required. Non-OVN/IPAM-only
-		// providers legitimately have no logical_switch and bypass this gate.
-		return !util.IsOvnProvider(provider), nil
+		// Without a persisted logical_switch this provider is not identifiable
+		// as a VPC subnet, so no tunnel_key is required. Normal OVN VPC
+		// allocation always writes logical_switch atomically with allocated.
+		return true, nil
 	}
 	subnet, err := csh.Controller.subnetsLister.Get(lsName)
 	if err != nil {
 		return false, fmt.Errorf("failed to get subnet %s: %w", lsName, err)
 	}
-	if !util.IsOvnVpcSubnet(subnet) {
-		return true, nil
-	}
-	tunnelKey, err := strconv.Atoi(pod.Annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)])
-	return err == nil && util.IsValidTunnelKey(tunnelKey) && tunnelKey == subnet.Status.TunnelKey, nil
+	return util.IsTunnelKeyAnnotationValidForSubnet(pod.Annotations, provider, subnet), nil
 }
 
 func (csh cniServerHandler) providerExists(provider string) (*kubeovnv1.Subnet, bool) {

--- a/pkg/daemon/handler.go
+++ b/pkg/daemon/handler.go
@@ -49,7 +49,10 @@ func createCniServerHandler(config *Configuration, controller *Controller) *cniS
 func (csh cniServerHandler) podTunnelKeyReady(pod *v1.Pod, provider string) (bool, error) {
 	lsName := pod.Annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)]
 	if lsName == "" {
-		return true, nil
+		// An allocated OVN provider must identify its logical switch before CNI
+		// can decide whether the VPC key is required. Non-OVN/IPAM-only
+		// providers legitimately have no logical_switch and bypass this gate.
+		return !util.IsOvnProvider(provider), nil
 	}
 	subnet, err := csh.Controller.subnetsLister.Get(lsName)
 	if err != nil {

--- a/pkg/daemon/handler_test.go
+++ b/pkg/daemon/handler_test.go
@@ -55,7 +55,7 @@ func TestPodTunnelKeyReady(t *testing.T) {
 		want     bool
 		wantErr  bool
 	}{
-		{name: "OVN provider without logical switch", pod: pod(util.OvnProvider, "", ""), provider: util.OvnProvider, want: false},
+		{name: "OVN provider without logical switch needs no VPC key", pod: pod(util.OvnProvider, "", ""), provider: util.OvnProvider, want: true},
 		{name: "non-OVN provider without logical switch", pod: pod("net1.default", "", ""), provider: "net1.default", want: true},
 		{name: "VPC key matches subnet status", pod: pod(util.OvnProvider, "vpc-subnet", "1234"), provider: util.OvnProvider, want: true},
 		{name: "custom OVN provider key matches", pod: pod("net1.default.ovn", "vpc-subnet", "1234"), provider: "net1.default.ovn", want: true},

--- a/pkg/daemon/handler_test.go
+++ b/pkg/daemon/handler_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+	kubeovnlister "github.com/kubeovn/kube-ovn/pkg/client/listers/kubeovn/v1"
+	"github.com/kubeovn/kube-ovn/pkg/util"
+)
+
+func TestPodTunnelKeyReady(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, subnet := range []*kubeovnv1.Subnet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "vpc-subnet"},
+			Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+			Status:     kubeovnv1.SubnetStatus{TunnelKey: 1234},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"},
+			Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"},
+		},
+	} {
+		if err := indexer.Add(subnet); err != nil {
+			t.Fatal(err)
+		}
+	}
+	csh := cniServerHandler{Controller: &Controller{
+		subnetsLister: kubeovnlister.NewSubnetLister(indexer),
+	}}
+	pod := func(subnet, tunnelKey string) *corev1.Pod {
+		annotations := map[string]string{}
+		if subnet != "" {
+			annotations[util.LogicalSwitchAnnotation] = subnet
+		}
+		if tunnelKey != "" {
+			annotations[util.TunnelKeyAnnotation] = tunnelKey
+		}
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+	}
+
+	tests := []struct {
+		name    string
+		pod     *corev1.Pod
+		want    bool
+		wantErr bool
+	}{
+		{name: "provider without logical switch", pod: pod("", ""), want: true},
+		{name: "VPC key matches subnet status", pod: pod("vpc-subnet", "1234"), want: true},
+		{name: "VPC key missing", pod: pod("vpc-subnet", ""), want: false},
+		{name: "VPC key zero", pod: pod("vpc-subnet", "0"), want: false},
+		{name: "VPC key non-numeric", pod: pod("vpc-subnet", "invalid"), want: false},
+		{name: "VPC key differs from subnet status", pod: pod("vpc-subnet", "999"), want: false},
+		{name: "vlan subnet needs no key", pod: pod("vlan-subnet", ""), want: true},
+		{name: "missing subnet", pod: pod("missing-subnet", "1234"), want: false, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := csh.podTunnelKeyReady(tt.pod, util.OvnProvider)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("podTunnelKeyReady() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("podTunnelKeyReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/daemon/handler_test.go
+++ b/pkg/daemon/handler_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +22,10 @@ func TestPodTunnelKeyReady(t *testing.T) {
 			Status:     kubeovnv1.SubnetStatus{TunnelKey: 1234},
 		},
 		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pending-vpc-subnet"},
+			Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider},
+		},
+		{
 			ObjectMeta: metav1.ObjectMeta{Name: "vlan-subnet"},
 			Spec:       kubeovnv1.SubnetSpec{Provider: util.OvnProvider, Vlan: "vlan-a"},
 		},
@@ -32,13 +37,13 @@ func TestPodTunnelKeyReady(t *testing.T) {
 	csh := cniServerHandler{Controller: &Controller{
 		subnetsLister: kubeovnlister.NewSubnetLister(indexer),
 	}}
-	pod := func(subnet, tunnelKey string) *corev1.Pod {
+	pod := func(provider, subnet, tunnelKey string) *corev1.Pod {
 		annotations := map[string]string{}
 		if subnet != "" {
-			annotations[util.LogicalSwitchAnnotation] = subnet
+			annotations[fmt.Sprintf(util.LogicalSwitchAnnotationTemplate, provider)] = subnet
 		}
 		if tunnelKey != "" {
-			annotations[util.TunnelKeyAnnotation] = tunnelKey
+			annotations[fmt.Sprintf(util.TunnelKeyAnnotationTemplate, provider)] = tunnelKey
 		}
 		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
 	}
@@ -50,15 +55,18 @@ func TestPodTunnelKeyReady(t *testing.T) {
 		want     bool
 		wantErr  bool
 	}{
-		{name: "OVN provider without logical switch", pod: pod("", ""), provider: util.OvnProvider, want: false},
-		{name: "non-OVN provider without logical switch", pod: pod("", ""), provider: "net1.default", want: true},
-		{name: "VPC key matches subnet status", pod: pod("vpc-subnet", "1234"), provider: util.OvnProvider, want: true},
-		{name: "VPC key missing", pod: pod("vpc-subnet", ""), provider: util.OvnProvider, want: false},
-		{name: "VPC key zero", pod: pod("vpc-subnet", "0"), provider: util.OvnProvider, want: false},
-		{name: "VPC key non-numeric", pod: pod("vpc-subnet", "invalid"), provider: util.OvnProvider, want: false},
-		{name: "VPC key differs from subnet status", pod: pod("vpc-subnet", "999"), provider: util.OvnProvider, want: false},
-		{name: "vlan subnet needs no key", pod: pod("vlan-subnet", ""), provider: util.OvnProvider, want: true},
-		{name: "missing subnet", pod: pod("missing-subnet", "1234"), provider: util.OvnProvider, want: false, wantErr: true},
+		{name: "OVN provider without logical switch", pod: pod(util.OvnProvider, "", ""), provider: util.OvnProvider, want: false},
+		{name: "non-OVN provider without logical switch", pod: pod("net1.default", "", ""), provider: "net1.default", want: true},
+		{name: "VPC key matches subnet status", pod: pod(util.OvnProvider, "vpc-subnet", "1234"), provider: util.OvnProvider, want: true},
+		{name: "custom OVN provider key matches", pod: pod("net1.default.ovn", "vpc-subnet", "1234"), provider: "net1.default.ovn", want: true},
+		{name: "VPC key missing", pod: pod(util.OvnProvider, "vpc-subnet", ""), provider: util.OvnProvider, want: false},
+		{name: "VPC key zero", pod: pod(util.OvnProvider, "vpc-subnet", "0"), provider: util.OvnProvider, want: false},
+		{name: "VPC key non-numeric", pod: pod(util.OvnProvider, "vpc-subnet", "invalid"), provider: util.OvnProvider, want: false},
+		{name: "VPC key differs from subnet status", pod: pod(util.OvnProvider, "vpc-subnet", "999"), provider: util.OvnProvider, want: false},
+		{name: "VPC subnet status not ready", pod: pod(util.OvnProvider, "pending-vpc-subnet", "1234"), provider: util.OvnProvider, want: false},
+		{name: "vlan subnet needs no key", pod: pod(util.OvnProvider, "vlan-subnet", ""), provider: util.OvnProvider, want: true},
+		{name: "vlan stale key does not block CNI", pod: pod(util.OvnProvider, "vlan-subnet", "1234"), provider: util.OvnProvider, want: true},
+		{name: "missing subnet", pod: pod(util.OvnProvider, "missing-subnet", "1234"), provider: util.OvnProvider, want: false, wantErr: true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/daemon/handler_test.go
+++ b/pkg/daemon/handler_test.go
@@ -44,24 +44,26 @@ func TestPodTunnelKeyReady(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		pod     *corev1.Pod
-		want    bool
-		wantErr bool
+		name     string
+		pod      *corev1.Pod
+		provider string
+		want     bool
+		wantErr  bool
 	}{
-		{name: "provider without logical switch", pod: pod("", ""), want: true},
-		{name: "VPC key matches subnet status", pod: pod("vpc-subnet", "1234"), want: true},
-		{name: "VPC key missing", pod: pod("vpc-subnet", ""), want: false},
-		{name: "VPC key zero", pod: pod("vpc-subnet", "0"), want: false},
-		{name: "VPC key non-numeric", pod: pod("vpc-subnet", "invalid"), want: false},
-		{name: "VPC key differs from subnet status", pod: pod("vpc-subnet", "999"), want: false},
-		{name: "vlan subnet needs no key", pod: pod("vlan-subnet", ""), want: true},
-		{name: "missing subnet", pod: pod("missing-subnet", "1234"), want: false, wantErr: true},
+		{name: "OVN provider without logical switch", pod: pod("", ""), provider: util.OvnProvider, want: false},
+		{name: "non-OVN provider without logical switch", pod: pod("", ""), provider: "net1.default", want: true},
+		{name: "VPC key matches subnet status", pod: pod("vpc-subnet", "1234"), provider: util.OvnProvider, want: true},
+		{name: "VPC key missing", pod: pod("vpc-subnet", ""), provider: util.OvnProvider, want: false},
+		{name: "VPC key zero", pod: pod("vpc-subnet", "0"), provider: util.OvnProvider, want: false},
+		{name: "VPC key non-numeric", pod: pod("vpc-subnet", "invalid"), provider: util.OvnProvider, want: false},
+		{name: "VPC key differs from subnet status", pod: pod("vpc-subnet", "999"), provider: util.OvnProvider, want: false},
+		{name: "vlan subnet needs no key", pod: pod("vlan-subnet", ""), provider: util.OvnProvider, want: true},
+		{name: "missing subnet", pod: pod("missing-subnet", "1234"), provider: util.OvnProvider, want: false, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := csh.podTunnelKeyReady(tt.pod, util.OvnProvider)
+			got, err := csh.podTunnelKeyReady(tt.pod, tt.provider)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("podTunnelKeyReady() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -26,6 +26,14 @@ var (
 		[]string{"node_name"},
 	)
 
+	cniWaitTunnelKeyResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cni_wait_tunnel_key_seconds_total",
+			Help: "Latency that CNI waits for the VPC tunnel_key annotation",
+		},
+		[]string{"node_name"},
+	)
+
 	cniWaitRouteResult = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cni_wait_route_seconds_total",
@@ -143,6 +151,7 @@ func InitMetrics() {
 	registerSystemParameterMetrics()
 	metrics.Registry.MustRegister(cniOperationHistogram)
 	metrics.Registry.MustRegister(cniWaitAddressResult)
+	metrics.Registry.MustRegister(cniWaitTunnelKeyResult)
 	metrics.Registry.MustRegister(cniConnectivityResult)
 }
 

--- a/pkg/util/subnet.go
+++ b/pkg/util/subnet.go
@@ -1,6 +1,24 @@
 package util
 
-import "strings"
+import (
+	"strings"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
+)
+
+// MaxTunnelKey is OVN's maximum 24-bit Datapath_Binding.tunnel_key value.
+const MaxTunnelKey = 1<<24 - 1
+
+func IsValidTunnelKey(key int) bool {
+	return key > 0 && key <= MaxTunnelKey
+}
+
+// IsOvnVpcSubnet reports whether a subnet participates in the VPC tunnel-key
+// guarantee. It includes default and custom VPCs; vlan is the only
+// VPC/underlay discriminator after the OVN-provider check.
+func IsOvnVpcSubnet(subnet *kubeovnv1.Subnet) bool {
+	return subnet != nil && IsOvnProvider(subnet.Spec.Provider) && subnet.Spec.Vlan == ""
+}
 
 func IsOvnProvider(provider string) bool {
 	if provider == "" || provider == OvnProvider {

--- a/pkg/util/subnet.go
+++ b/pkg/util/subnet.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
@@ -18,6 +20,17 @@ func IsValidTunnelKey(key int) bool {
 // VPC/underlay discriminator after the OVN-provider check.
 func IsOvnVpcSubnet(subnet *kubeovnv1.Subnet) bool {
 	return subnet != nil && IsOvnProvider(subnet.Spec.Provider) && subnet.Spec.Vlan == ""
+}
+
+// IsTunnelKeyAnnotationValidForSubnet reports whether a provider annotation
+// carries the exact valid key required by a non-vlan OVN VPC subnet. Other
+// subnet types do not require the annotation and therefore return true.
+func IsTunnelKeyAnnotationValidForSubnet(annotations map[string]string, provider string, subnet *kubeovnv1.Subnet) bool {
+	if !IsOvnVpcSubnet(subnet) {
+		return true
+	}
+	tunnelKey, err := strconv.Atoi(annotations[fmt.Sprintf(TunnelKeyAnnotationTemplate, provider)])
+	return err == nil && IsValidTunnelKey(tunnelKey) && tunnelKey == subnet.Status.TunnelKey
 }
 
 func IsOvnProvider(provider string) bool {

--- a/pkg/util/subnet_test.go
+++ b/pkg/util/subnet_test.go
@@ -84,6 +84,37 @@ func TestIsOvnVpcSubnet(t *testing.T) {
 	}
 }
 
+func TestIsTunnelKeyAnnotationValidForSubnet(t *testing.T) {
+	vpcSubnet := &kubeovnv1.Subnet{
+		Spec:   kubeovnv1.SubnetSpec{Provider: OvnProvider},
+		Status: kubeovnv1.SubnetStatus{TunnelKey: 1234},
+	}
+	vlanSubnet := &kubeovnv1.Subnet{Spec: kubeovnv1.SubnetSpec{Provider: OvnProvider, Vlan: "vlan-a"}}
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		provider    string
+		subnet      *kubeovnv1.Subnet
+		want        bool
+	}{
+		{name: "matching default provider key", annotations: map[string]string{TunnelKeyAnnotation: "1234"}, provider: OvnProvider, subnet: vpcSubnet, want: true},
+		{name: "matching custom provider key", annotations: map[string]string{"net1.default.ovn.kubernetes.io/tunnel_key": "1234"}, provider: "net1.default.ovn", subnet: vpcSubnet, want: true},
+		{name: "missing key", annotations: map[string]string{}, provider: OvnProvider, subnet: vpcSubnet},
+		{name: "invalid key", annotations: map[string]string{TunnelKeyAnnotation: "invalid"}, provider: OvnProvider, subnet: vpcSubnet},
+		{name: "stale key", annotations: map[string]string{TunnelKeyAnnotation: "999"}, provider: OvnProvider, subnet: vpcSubnet},
+		{name: "vlan requires no key", annotations: map[string]string{}, provider: OvnProvider, subnet: vlanSubnet, want: true},
+		{name: "non-OVN or unidentified subnet requires no key", annotations: map[string]string{}, provider: "net1.default", subnet: nil, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTunnelKeyAnnotationValidForSubnet(tt.annotations, tt.provider, tt.subnet); got != tt.want {
+				t.Errorf("IsTunnelKeyAnnotationValidForSubnet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsOvnProvider(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/pkg/util/subnet_test.go
+++ b/pkg/util/subnet_test.go
@@ -2,7 +2,87 @@ package util
 
 import (
 	"testing"
+
+	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 )
+
+func TestIsValidTunnelKey(t *testing.T) {
+	tests := []struct {
+		key  int
+		want bool
+	}{
+		{key: -1, want: false},
+		{key: 0, want: false},
+		{key: 1, want: true},
+		{key: MaxTunnelKey, want: true},
+		{key: MaxTunnelKey + 1, want: false},
+	}
+	for _, tt := range tests {
+		if got := IsValidTunnelKey(tt.key); got != tt.want {
+			t.Errorf("IsValidTunnelKey(%d) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestIsOvnVpcSubnet(t *testing.T) {
+	tests := []struct {
+		name   string
+		subnet *kubeovnv1.Subnet
+		want   bool
+	}{
+		{name: "nil", subnet: nil, want: false},
+		{
+			name: "implicit default VPC non-vlan subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: ""},
+			},
+			want: true,
+		},
+		{
+			name: "default cluster router VPC non-vlan subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: OvnProvider, Vpc: DefaultVpc},
+			},
+			want: true,
+		},
+		{
+			name: "custom VPC non-vlan subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: OvnProvider, Vpc: "custom-vpc"},
+			},
+			want: true,
+		},
+		{
+			name: "default VPC vlan underlay subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: OvnProvider, Vpc: DefaultVpc, Vlan: "vlan-a"},
+			},
+			want: false,
+		},
+		{
+			name: "custom VPC vlan underlay subnet",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: OvnProvider, Vpc: "custom-vpc", Vlan: "vlan-a"},
+			},
+			want: false,
+		},
+		{
+			name: "non-OVN provider",
+			subnet: &kubeovnv1.Subnet{
+				Spec: kubeovnv1.SubnetSpec{Provider: "external.provider"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOvnVpcSubnet(tt.subnet); got != tt.want {
+				t.Errorf("IsOvnVpcSubnet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestIsOvnProvider(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION

 本 PR 的主题， 两个方式保证 tun id 有效：
- 是通过 pod cni add 之前
- 以及 kube-ovn-controller 启动 init 时 

保证 ovn vpc 子网内的 pod 均具备 annotation 中的 tunnel key vpc subnet 对应的 id。
不需要 定时任务也可保证完备（不包括覆盖意外手动删除的情况）。

再次 review 确认代码的正确性，完备性，按照简单必要原则移除（无效｜可复用）代码，确保 UT 完备。



# Pull Request

- [ ] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

## What type of this PR

Examples of user facing changes:
<!-- 
Select one or more options that fit this PR.
-->

- Features
- Bug fixes
- Docs
- Tests

<!-- 
Describe your changes here, ideally you can get that description straight from your descriptive commit message(s)!
-->

## Which issue(s) this PR fixes

Fixes #(issue-number)
